### PR TITLE
VFD-63: Added consent fields to the user profile

### DIFF
--- a/Tools/Docker/docker-compose-localdev.yml
+++ b/Tools/Docker/docker-compose-localdev.yml
@@ -9,7 +9,8 @@ services:
     ports:
       - 5001:80
     depends_on:
-      - postgresdb
+      postgresdb:
+        condition: service_healthy
     environment:
       ASPNETCORE_ENVIRONMENT: Development
       CONNECTIONSTRINGS__DEFAULTCONNECTION: Host=postgresdb;Database=postgres;Username=postgres;Password=example
@@ -18,6 +19,11 @@ services:
     container_name: postgresdb
     image: postgres
     restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     ports:
       - 5432:5432
     environment:

--- a/Tools/Scripts/startApiInDocker-arm64.sh
+++ b/Tools/Scripts/startApiInDocker-arm64.sh
@@ -11,5 +11,6 @@ cd ../../../
 echo "Work Directory:"
 pwd
 docker-compose -f ./Tools/Docker/docker-compose-localdev.yml up
+docker-compose -f ./Tools/Docker/docker-compose-localdev.yml down
 
 

--- a/Tools/Scripts/startApiInDocker-arm64.sh
+++ b/Tools/Scripts/startApiInDocker-arm64.sh
@@ -5,7 +5,7 @@ cd ./VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI
 echo "Work Directory:"
 pwd
 echo "Building Docker Image of API"
-docker build -t virtualfinland/usersapi:latest .
+docker build -f Dockerfile.arm64 -t virtualfinland/usersapi:latest .
 echo "Starting LocalDev in Docker"
 cd ../../../
 echo "Work Directory:"

--- a/Tools/Scripts/startApiInDocker.sh
+++ b/Tools/Scripts/startApiInDocker.sh
@@ -11,5 +11,5 @@ cd ../../../
 echo "Work Directory:"
 pwd
 docker-compose -f ./Tools/Docker/docker-compose-localdev.yml up
-
+docker-compose -f ./Tools/Docker/docker-compose-localdev.yml down
 

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/CodeSets/CodeSetsController.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/CodeSets/CodeSetsController.cs
@@ -29,4 +29,13 @@ public class CodeSetsController : ControllerBase
     {
         return Ok(await _mediator.Send(new GetAllCountries.Query()));
     }
+    
+    [HttpGet("/code-sets/countries/{countryCode}")]
+    [SwaggerOperation(Summary = "Get all available ISO 3166 country codes and details", Description = "Get all available ISO 3166 country codes and details.")]
+    [ProducesResponseType(typeof(GetCountry.Country),StatusCodes.Status200OK)]
+    [ProducesErrorResponseType(typeof(Microsoft.AspNetCore.Mvc.ProblemDetails))]
+    public async Task<IActionResult> GetTestbedIdentityUser(string countryCode)
+    {
+        return Ok(await _mediator.Send(new GetCountry.Query(countryCode)));
+    }
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/CodeSets/CodeSetsController.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/CodeSets/CodeSetsController.cs
@@ -1,0 +1,32 @@
+using System.Security.Claims;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using VirtualFinland.UserAPI.Activities.CodeSets.Operations;
+using VirtualFinland.UserAPI.Activities.User.Operations;
+
+namespace VirtualFinland.UserAPI.Activities.CodeSets;
+
+[ApiController]
+[Authorize]
+[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+[Produces("application/json")]
+public class CodeSetsController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public CodeSetsController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet("/code-sets/countries")]
+    [SwaggerOperation(Summary = "Get all available ISO 3166 country codes and details", Description = "Get all available ISO 3166 country codes and details.")]
+    [ProducesResponseType(typeof(List<GetAllCountries.Country>),StatusCodes.Status200OK)]
+    [ProducesErrorResponseType(typeof(Microsoft.AspNetCore.Mvc.ProblemDetails))]
+    public async Task<IActionResult> GetTestbedIdentityUser()
+    {
+        return Ok(await _mediator.Send(new GetAllCountries.Query()));
+    }
+}

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/CodeSets/CodeSetsController.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/CodeSets/CodeSetsController.cs
@@ -31,7 +31,7 @@ public class CodeSetsController : ControllerBase
     }
     
     [HttpGet("/code-sets/countries/{countryCode}")]
-    [SwaggerOperation(Summary = "Get all available ISO 3166 country codes and details", Description = "Get all available ISO 3166 country codes and details.")]
+    [SwaggerOperation(Summary = "Gets a single country and its details by it's Two Letter ISO Code", Description = "Gets a single country and its details by it's Two Letter ISO Code.")]
     [ProducesResponseType(typeof(GetCountry.Country),StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesErrorResponseType(typeof(Microsoft.AspNetCore.Mvc.ProblemDetails))]

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/CodeSets/CodeSetsController.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/CodeSets/CodeSetsController.cs
@@ -33,6 +33,7 @@ public class CodeSetsController : ControllerBase
     [HttpGet("/code-sets/countries/{countryCode}")]
     [SwaggerOperation(Summary = "Get all available ISO 3166 country codes and details", Description = "Get all available ISO 3166 country codes and details.")]
     [ProducesResponseType(typeof(GetCountry.Country),StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesErrorResponseType(typeof(Microsoft.AspNetCore.Mvc.ProblemDetails))]
     public async Task<IActionResult> GetTestbedIdentityUser(string countryCode)
     {

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/CodeSets/Operations/GetAllCountries.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/CodeSets/Operations/GetAllCountries.cs
@@ -1,10 +1,12 @@
 using System.Globalization;
 using MediatR;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace VirtualFinland.UserAPI.Activities.CodeSets.Operations;
 
 public class GetAllCountries
 {
+    [SwaggerSchema(Title = "CountryCodeSetRequest")]
     public class Query : IRequest<List<Country>>
     {
         
@@ -20,6 +22,7 @@ public class GetAllCountries
         }
     }
 
+    [SwaggerSchema(Title = "CountryCodeSetResponse")]
     public record Country(string Nane, string DisplayName, string EnglishName, string NativeName, string TwoLetterISORegionName, string ThreeLetterISORegionName);
 }
 

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/CodeSets/Operations/GetAllCountries.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/CodeSets/Operations/GetAllCountries.cs
@@ -17,8 +17,20 @@ public class GetAllCountries
 
         public async Task<List<Country>> Handle(Query request, CancellationToken cancellationToken)
         {
-            return CultureInfo.GetCultures(CultureTypes.AllCultures).Select(o => new Country(o.Name, o.DisplayName, o.EnglishName, o.NativeName, o.TwoLetterISOLanguageName, o.ThreeLetterISOLanguageName))
+            return GetCountriesByIso3166().Select(o => new Country(o.Name, o.DisplayName, o.EnglishName, o.NativeName, o.TwoLetterISORegionName, o.ThreeLetterISORegionName))
                 .ToList();
+        }
+        
+        public static List<RegionInfo> GetCountriesByIso3166()
+        {
+            List<RegionInfo> countries = new List<RegionInfo>();
+            foreach (CultureInfo culture in CultureInfo.GetCultures(CultureTypes.SpecificCultures))
+            {
+                RegionInfo country = new RegionInfo(culture.Name);
+                if (countries.Count(p => p.Name == country.Name) == 0)
+                    countries.Add(country);
+            }
+            return countries.OrderBy(p => p.EnglishName).ToList();
         }
     }
 

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/CodeSets/Operations/GetAllCountries.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/CodeSets/Operations/GetAllCountries.cs
@@ -1,0 +1,25 @@
+using System.Globalization;
+using MediatR;
+
+namespace VirtualFinland.UserAPI.Activities.CodeSets.Operations;
+
+public class GetAllCountries
+{
+    public class Query : IRequest<List<Country>>
+    {
+        
+    }
+
+    public class Handler : IRequestHandler<Query, List<Country>>
+    {
+
+        public async Task<List<Country>> Handle(Query request, CancellationToken cancellationToken)
+        {
+            return CultureInfo.GetCultures(CultureTypes.AllCultures).Select(o => new Country(o.Name, o.DisplayName, o.EnglishName, o.NativeName, o.TwoLetterISOLanguageName, o.ThreeLetterISOLanguageName))
+                .ToList();
+        }
+    }
+
+    public record Country(string Nane, string DisplayName, string EnglishName, string NativeName, string TwoLetterISORegionName, string ThreeLetterISORegionName);
+}
+

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/CodeSets/Operations/GetCountry.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/CodeSets/Operations/GetCountry.cs
@@ -25,12 +25,12 @@ public class GetCountry
         {
             try
             {
-                var country = CultureInfo.GetCultureInfo(request.ISOCode, true);
-                return new Country(country.Name, country.DisplayName, country.EnglishName, country.NativeName, country.TwoLetterISOLanguageName, country.ThreeLetterISOLanguageName);
+                var country = new RegionInfo(request.ISOCode);
+                return new Country(country.Name, country.DisplayName, country.EnglishName, country.NativeName, country.TwoLetterISORegionName, country.ThreeLetterISORegionName);
             }
-            catch (CultureNotFoundException e)
+            catch (ArgumentException e)
             {
-                throw new NotFoundException("Given culture not found");
+                throw new NotFoundException("Given culture not found", e);
             }
             
         }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/CodeSets/Operations/GetCountry.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/CodeSets/Operations/GetCountry.cs
@@ -1,0 +1,42 @@
+using System.Globalization;
+using MediatR;
+using Swashbuckle.AspNetCore.Annotations;
+using VirtualFinland.UserAPI.Exceptions;
+
+namespace VirtualFinland.UserAPI.Activities.CodeSets.Operations;
+
+public class GetCountry
+{
+    [SwaggerSchema(Title = "CountryCodeSetRequest")]
+    public class Query : IRequest<Country>
+    {
+        public string ISOCode { get; }
+
+        public Query(string isoCode)
+        {
+            this.ISOCode = isoCode;
+        }
+    }
+
+    public class Handler : IRequestHandler<Query, Country>
+    {
+
+        public async Task<Country> Handle(Query request, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var country = CultureInfo.GetCultureInfo(request.ISOCode, true);
+                return new Country(country.Name, country.DisplayName, country.EnglishName, country.NativeName, country.TwoLetterISOLanguageName, country.ThreeLetterISOLanguageName);
+            }
+            catch (CultureNotFoundException e)
+            {
+                throw new NotFoundException("Given culture not found");
+            }
+            
+        }
+    }
+
+    [SwaggerSchema(Title = "CountryCodeSetResponse")]
+    public record Country(string Nane, string DisplayName, string EnglishName, string NativeName, string TwoLetterISORegionName, string ThreeLetterISORegionName);
+}
+

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/GetUser.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/GetUser.cs
@@ -42,7 +42,7 @@ public class GetUser
             var dbUserDefaultSearchProfile = await _usersDbContext.SearchProfiles.FirstOrDefaultAsync(o => o.IsDefault == true && o.UserId == dbUser.Id, cancellationToken);
             _logger.LogDebug("User data retrieved for user: {DbUserId}", dbUser.Id);
             
-            return new User(dbUser.Id, dbUser.FirstName, dbUser.LastName, dbUser.Address, dbUserDefaultSearchProfile?.JobTitles, dbUserDefaultSearchProfile?.Regions, dbUser.Created, dbUser.Modified);
+            return new User(dbUser.Id, dbUser.FirstName, dbUser.LastName, dbUser.Address, dbUserDefaultSearchProfile?.JobTitles, dbUserDefaultSearchProfile?.Regions, dbUser.Created, dbUser.Modified, dbUser.ImmigrationDataConsent, dbUser.JobsDataConsent);
         }
         
         async private Task<Models.User> GetAuthenticatedUser(Query request, CancellationToken cancellationToken)
@@ -61,6 +61,6 @@ public class GetUser
     }
     
     [SwaggerSchema(Title = "UserResponse")]
-    public record User(Guid Id, string? FirstName, string? LastName, string? address, List<string>? JobTitles, List<string>? Regions, DateTime Created, DateTime Modified);
+    public record User(Guid Id, string? FirstName, string? LastName, string? address, List<string>? JobTitles, List<string>? Regions, DateTime Created, DateTime Modified, bool ImmigrationDataConsent, bool JobsDataConsent);
     
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/GetUser.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/GetUser.cs
@@ -42,7 +42,20 @@ public class GetUser
             var dbUserDefaultSearchProfile = await _usersDbContext.SearchProfiles.FirstOrDefaultAsync(o => o.IsDefault == true && o.UserId == dbUser.Id, cancellationToken);
             _logger.LogDebug("User data retrieved for user: {DbUserId}", dbUser.Id);
             
-            return new User(dbUser.Id, dbUser.FirstName, dbUser.LastName, dbUser.Address, dbUserDefaultSearchProfile?.JobTitles, dbUserDefaultSearchProfile?.Regions, dbUser.Created, dbUser.Modified, dbUser.ImmigrationDataConsent, dbUser.JobsDataConsent);
+            return new User(dbUser.Id,
+                dbUser.FirstName,
+                dbUser.LastName,
+                dbUser.Address,
+                dbUserDefaultSearchProfile?.JobTitles,
+                dbUserDefaultSearchProfile?.Regions,
+                dbUser.Created,
+                dbUser.Modified,
+                dbUser.ImmigrationDataConsent,
+                dbUser.JobsDataConsent,
+                dbUser.CountryOfBirthISOCode,
+                dbUser.NativeLanguageISOCode,
+                dbUser.ProfessionISCOCode,
+                dbUser.NationalityISOCode);
         }
         
         async private Task<Models.User> GetAuthenticatedUser(Query request, CancellationToken cancellationToken)
@@ -61,6 +74,19 @@ public class GetUser
     }
     
     [SwaggerSchema(Title = "UserResponse")]
-    public record User(Guid Id, string? FirstName, string? LastName, string? address, List<string>? JobTitles, List<string>? Regions, DateTime Created, DateTime Modified, bool ImmigrationDataConsent, bool JobsDataConsent);
+    public record User(Guid Id,
+        string? FirstName,
+        string? LastName,
+        string? address,
+        List<string>? JobTitles,
+        List<string>? Regions,
+        DateTime Created,
+        DateTime Modified,
+        bool ImmigrationDataConsent,
+        bool JobsDataConsent,
+        string? CountryOfBirthISO,
+        string? NativeLanguageISO,
+        string? ProfessionISCO,
+        string? NationalityISO);
     
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/UpdateUser.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/UpdateUser.cs
@@ -20,6 +20,14 @@ public class UpdateUser
         public bool? JobsDataConsent { get; set; }
         
         public bool? ImmigrationDataConsent { get; set; }
+        
+        public string? CountryOfBirthISO { get; set; }
+
+        public string? NativeLanguageISO { get; set; }
+
+        public string? ProfessionISCO { get; set; }
+
+        public string? NationalityISO { get; set; }
 
         public List<string>? JobTitles { get; }
         public List<string>? Regions { get; }
@@ -29,13 +37,27 @@ public class UpdateUser
         [SwaggerIgnore]
         public string? ClaimsIssuer { get; set; }
 
-        public Command(string? firstName, string? lastName, string? address, bool? jobsDataConsent, bool? immigrationDataConsent, List<string>? jobTitles, List<string>? regions)
+        public Command(string? firstName,
+            string? lastName,
+            string? address,
+            bool? jobsDataConsent,
+            bool? immigrationDataConsent,
+            string? countryOfBirthIso,
+            string? nativeLanguageIso,
+            string? professionIsco,
+            string? nationalityIso,
+            List<string>? jobTitles,
+            List<string>? regions)
         {
             this.FirstName = firstName;
             this.LastName = lastName;
             this.Address = address;
             this.JobsDataConsent = jobsDataConsent;
             this.ImmigrationDataConsent = immigrationDataConsent;
+            this.CountryOfBirthISO = countryOfBirthIso;
+            this.NativeLanguageISO = nativeLanguageIso;
+            this.ProfessionISCO = professionIsco;
+            this.NationalityISO = nationalityIso;
             this.JobTitles = jobTitles;
             this.Regions = regions;
         }
@@ -68,6 +90,10 @@ public class UpdateUser
                 dbUser.Modified = DateTime.UtcNow;
                 dbUser.ImmigrationDataConsent = request.ImmigrationDataConsent ?? dbUser.ImmigrationDataConsent;
                 dbUser.JobsDataConsent = request.JobsDataConsent ?? dbUser.JobsDataConsent;
+                dbUser.NationalityISOCode = request.NationalityISO ?? dbUser.NationalityISOCode;
+                dbUser.NativeLanguageISOCode = request.NativeLanguageISO ?? dbUser.NativeLanguageISOCode;
+                dbUser.ProfessionISCOCode = request.ProfessionISCO ?? dbUser.ProfessionISCOCode;
+                dbUser.CountryOfBirthISOCode = request.CountryOfBirthISO ?? dbUser.CountryOfBirthISOCode;
 
                 // TODO - To be decided: This default search profile in the user API call can be possibly removed when requirement are more clear
                 var dbUserDefaultSearchProfile = await _usersDbContext.SearchProfiles.FirstOrDefaultAsync(o => o.IsDefault == true && o.UserId == dbUser.Id, cancellationToken);

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/UpdateUser.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/UpdateUser.cs
@@ -16,6 +16,10 @@ public class UpdateUser
         public string? LastName { get; }
         
         public string? Address { get; set; }
+        
+        public bool? JobsDataConsent { get; set; }
+        
+        public bool? ImmigrationDataConsent { get; set; }
 
         public List<string>? JobTitles { get; }
         public List<string>? Regions { get; }
@@ -25,10 +29,13 @@ public class UpdateUser
         [SwaggerIgnore]
         public string? ClaimsIssuer { get; set; }
 
-        public Command(string? firstName, string? lastName, List<string> jobTitles, List<string> regions)
+        public Command(string? firstName, string? lastName, string? address, bool? jobsDataConsent, bool? immigrationDataConsent, List<string>? jobTitles, List<string>? regions)
         {
             this.FirstName = firstName;
             this.LastName = lastName;
+            this.Address = address;
+            this.JobsDataConsent = jobsDataConsent;
+            this.ImmigrationDataConsent = immigrationDataConsent;
             this.JobTitles = jobTitles;
             this.Regions = regions;
         }
@@ -59,7 +66,9 @@ public class UpdateUser
                 dbUser.LastName = request.LastName ?? dbUser.LastName;
                 dbUser.Address = request.Address ?? dbUser.Address;
                 dbUser.Modified = DateTime.UtcNow;
-                
+                dbUser.ImmigrationDataConsent = request.ImmigrationDataConsent ?? dbUser.ImmigrationDataConsent;
+                dbUser.JobsDataConsent = request.JobsDataConsent ?? dbUser.JobsDataConsent;
+
                 // TODO - To be decided: This default search profile in the user API call can be possibly removed when requirement are more clear
                 var dbUserDefaultSearchProfile = await _usersDbContext.SearchProfiles.FirstOrDefaultAsync(o => o.IsDefault == true && o.UserId == dbUser.Id, cancellationToken);
 
@@ -91,7 +100,7 @@ public class UpdateUser
                 
                 _logger.LogDebug("User data updated for user: {DbUserId}", dbUser.Id);
                 
-                return new User(dbUser.Id, dbUser.FirstName, dbUser.LastName, dbUser.Address, dbUserDefaultSearchProfile?.JobTitles, dbUserDefaultSearchProfile?.Regions, dbUser.Created, dbUser.Modified);
+                return new User(dbUser.Id, dbUser.FirstName, dbUser.LastName, dbUser.Address, dbUserDefaultSearchProfile?.JobTitles, dbUserDefaultSearchProfile?.Regions, dbUser.Created, dbUser.Modified, dbUser.ImmigrationDataConsent, dbUser.JobsDataConsent);
             }
             
             async private Task<Models.User> GetAuthenticatedUser(Command request, CancellationToken cancellationToken)
@@ -111,5 +120,5 @@ public class UpdateUser
             
         }
     [SwaggerSchema(Title = "UpdateUserResponse")]
-    public record User(Guid Id, string? FirstName, string? LastName, string? address, List<string>? JobTitles, List<string>? Regions, DateTime Created, DateTime Modified);
+    public record User(Guid Id, string? FirstName, string? LastName, string? address, List<string>? JobTitles, List<string>? Regions, DateTime Created, DateTime Modified, bool ImmigrationDataConsent, bool JobsDataConsent);
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/UpdateUser.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/UpdateUser.cs
@@ -100,7 +100,20 @@ public class UpdateUser
                 
                 _logger.LogDebug("User data updated for user: {DbUserId}", dbUser.Id);
                 
-                return new User(dbUser.Id, dbUser.FirstName, dbUser.LastName, dbUser.Address, dbUserDefaultSearchProfile?.JobTitles, dbUserDefaultSearchProfile?.Regions, dbUser.Created, dbUser.Modified, dbUser.ImmigrationDataConsent, dbUser.JobsDataConsent);
+                return new User(dbUser.Id,
+                    dbUser.FirstName,
+                    dbUser.LastName,
+                    dbUser.Address,
+                    dbUserDefaultSearchProfile?.JobTitles,
+                    dbUserDefaultSearchProfile?.Regions,
+                    dbUser.Created,
+                    dbUser.Modified,
+                    dbUser.ImmigrationDataConsent,
+                    dbUser.JobsDataConsent,
+                    dbUser.CountryOfBirthISOCode,
+                    dbUser.NativeLanguageISOCode,
+                    dbUser.ProfessionISCOCode,
+                    dbUser.NationalityISOCode);
             }
             
             async private Task<Models.User> GetAuthenticatedUser(Command request, CancellationToken cancellationToken)
@@ -120,5 +133,18 @@ public class UpdateUser
             
         }
     [SwaggerSchema(Title = "UpdateUserResponse")]
-    public record User(Guid Id, string? FirstName, string? LastName, string? address, List<string>? JobTitles, List<string>? Regions, DateTime Created, DateTime Modified, bool ImmigrationDataConsent, bool JobsDataConsent);
+    public record User(Guid Id,
+        string? FirstName,
+        string? LastName,
+        string? address,
+        List<string>? JobTitles,
+        List<string>? Regions,
+        DateTime Created,
+        DateTime Modified,
+        bool ImmigrationDataConsent,
+        bool JobsDataConsent,
+        string? CountryOfBirthISO,
+        string? NativeLanguageISO,
+        string? ProfessionISCO,
+        string? NationalityISO);
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Dockerfile.arm64
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Dockerfile.arm64
@@ -12,7 +12,7 @@ RUN dotnet restore "VirtualFinland.UsersAPI.csproj"
 COPY . .
 RUN dotnet build "VirtualFinland.UsersAPI.csproj" -c Release -o /app/build
 FROM build AS publish
-RUN dotnet publish "VirtualFinland.UsersAPI.csproj" -c Release -o /app/publish
+RUN dotnet publish "VirtualFinland.UsersAPI.csproj" -p:PublishReadyToRun=True -p:PublishReadyToRunUseCrossgen2=True -c Release -o /app/publish -r $runtimeType
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/TestBedIdentityProviderConfig.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/TestBedIdentityProviderConfig.cs
@@ -7,6 +7,11 @@ public class TestBedIdentityProviderConfig : IIdentityProviderConfig
     private readonly IConfiguration _configuration;
     private string? _issuer;
     private string? _jwksOptionsUrl;
+    private readonly int _configUrlMaxRetryCount = 5;
+    /// <summary>
+    /// How long to wait in milliseconds before trying again to retrieve the openid configs
+    /// </summary>
+    private readonly int _configUrlRetryWaitTime = 3000;
 
     public string? JwksOptionsUrl
     {
@@ -28,12 +33,27 @@ public class TestBedIdentityProviderConfig : IIdentityProviderConfig
         var testBedConfigUrl = _configuration["Testbed:OpenIDConfigurationURL"];
         var httpClient = new HttpClient();
         var httpResponse = await httpClient.GetAsync(testBedConfigUrl);
-
-        if (httpResponse.IsSuccessStatusCode)
+        
+        for (int retryCount = 0; retryCount < _configUrlMaxRetryCount; retryCount++)
         {
-            var jsonData = JsonNode.Parse(await httpResponse.Content.ReadAsStringAsync());
-            _issuer = jsonData?["issuer"]?.ToString();
-            _jwksOptionsUrl = jsonData?["jwks_uri"]?.ToString();
+            if (httpResponse.IsSuccessStatusCode)
+            {
+                var jsonData = JsonNode.Parse(await httpResponse.Content.ReadAsStringAsync());
+                _issuer = jsonData?["issuer"]?.ToString();
+                _jwksOptionsUrl = jsonData?["jwks_uri"]?.ToString();
+
+                if (!string.IsNullOrEmpty(_issuer) && !string.IsNullOrEmpty(_jwksOptionsUrl))
+                {
+                    break;    
+                }
+                Thread.Sleep(_configUrlRetryWaitTime);
+            }    
+        }
+        
+        // If all retries fail, then send an exception since the security information is critical to the functionality of the backend
+        if (string.IsNullOrEmpty(_issuer) || string.IsNullOrEmpty(_jwksOptionsUrl))
+        {
+            throw new ApplicationException("Failed to retrieve TestBed OpenID configurations.");
         }
     }
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/TestBedIdentityProviderConfig.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/TestBedIdentityProviderConfig.cs
@@ -46,8 +46,8 @@ public class TestBedIdentityProviderConfig : IIdentityProviderConfig
                 {
                     break;    
                 }
-                Thread.Sleep(_configUrlRetryWaitTime);
             }    
+            Thread.Sleep(_configUrlRetryWaitTime);
         }
         
         // If all retries fail, then send an exception since the security information is critical to the functionality of the backend

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20221014102749_ConsentFields.Designer.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20221014102749_ConsentFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using VirtualFinland.UserAPI.Data;
@@ -12,9 +13,10 @@ using VirtualFinland.UserAPI.Data;
 namespace VirtualFinland.UserAPI.Migrations
 {
     [DbContext(typeof(UsersDbContext))]
-    partial class UsersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221014102749_ConsentFields")]
+    partial class ConsentFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20221014102749_ConsentFields.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20221014102749_ConsentFields.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VirtualFinland.UserAPI.Migrations
+{
+    public partial class ConsentFields : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "ImmigrationDataConsent",
+                table: "Users",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "JobsDataConsent",
+                table: "Users",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ImmigrationDataConsent",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "JobsDataConsent",
+                table: "Users");
+        }
+    }
+}

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20221019110901_AdditionalUserInformationFields.Designer.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20221019110901_AdditionalUserInformationFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using VirtualFinland.UserAPI.Data;
@@ -12,9 +13,10 @@ using VirtualFinland.UserAPI.Data;
 namespace VirtualFinland.UserAPI.Migrations
 {
     [DbContext(typeof(UsersDbContext))]
-    partial class UsersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221019110901_AdditionalUserInformationFields")]
+    partial class AdditionalUserInformationFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20221019110901_AdditionalUserInformationFields.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20221019110901_AdditionalUserInformationFields.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VirtualFinland.UserAPI.Migrations
+{
+    public partial class AdditionalUserInformationFields : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CountryOfBirthISOCode",
+                table: "Users",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "DateOfBirth",
+                table: "Users",
+                type: "date",
+                nullable: false,
+                defaultValue: new DateOnly(1, 1, 1));
+
+            migrationBuilder.AddColumn<string>(
+                name: "Gender",
+                table: "Users",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "NationalityISOCode",
+                table: "Users",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "NativeLanguageISOCode",
+                table: "Users",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ProfessionISCOCode",
+                table: "Users",
+                type: "text",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CountryOfBirthISOCode",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "DateOfBirth",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "Gender",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "NationalityISOCode",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "NativeLanguageISOCode",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "ProfessionISCOCode",
+                table: "Users");
+        }
+    }
+}

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/User.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/User.cs
@@ -20,4 +20,16 @@ public class User : IEntity
     public bool ImmigrationDataConsent { get; set; }
     
     public bool JobsDataConsent { get; set; }
+    
+    public DateOnly DateOfBirth { get; set; }
+    
+    public string? Gender { get; set; }
+
+    public string? CountryOfBirthISOCode { get; set; }
+
+    public string? NativeLanguageISOCode { get; set; }
+
+    public string? ProfessionISCOCode { get; set; }
+
+    public string? NationalityISOCode { get; set; }
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/User.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/User.cs
@@ -16,4 +16,8 @@ public class User : IEntity
     public string? LastName { get; set; }
     
     public string? Address { get; set; }
+    
+    public bool ImmigrationDataConsent { get; set; }
+    
+    public bool JobsDataConsent { get; set; }
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Program.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Net.Http.Headers;
 using Microsoft.OpenApi.Models;
 using NetDevPack.Security.JwtExtensions;
 using VirtualFinland.UserAPI.Data;
@@ -24,8 +25,8 @@ builder.Services.AddHttpClient();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 var securityScheme = new OpenApiSecurityScheme()
 {
-    Name = "Authorization",
-    Type = SecuritySchemeType.ApiKey,
+    Name = HeaderNames.Authorization,
+    Type = SecuritySchemeType.Http,
     Scheme = "Bearer",
     BearerFormat = "JWT",
     In = ParameterLocation.Header,
@@ -41,7 +42,9 @@ var securityReq = new OpenApiSecurityRequirement()
             {
                 Type = ReferenceType.SecurityScheme,
                 Id = "Bearer"
-            }
+            },
+            Scheme = SecuritySchemeType.Http.ToString(),
+            In = ParameterLocation.Header
         },
         new string[]
         {

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Program.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Program.cs
@@ -61,7 +61,7 @@ builder.Services.AddSwaggerGen(config =>
 });
 
 var dbConnectionString = Environment.GetEnvironmentVariable("DB_CONNECTION") ?? builder.Configuration.GetConnectionString("DefaultConnection");
-builder.Services.AddDbContext<UsersDbContext>(options => { options.UseNpgsql(dbConnectionString, op => op.EnableRetryOnFailure()); });
+builder.Services.AddDbContext<UsersDbContext>(options => { options.UseNpgsql(dbConnectionString, op => op.EnableRetryOnFailure(5, TimeSpan.FromSeconds(5), new List<string>())); });
 
 IIdentityProviderConfig identityProviderConfig = new TestBedIdentityProviderConfig(builder.Configuration);
 identityProviderConfig.LoadOpenIDConfigUrl();

--- a/VirtualFinland.UsersAPI.IntegrationTests/Helpers/APIUserFactory.cs
+++ b/VirtualFinland.UsersAPI.IntegrationTests/Helpers/APIUserFactory.cs
@@ -17,7 +17,9 @@ public class APIUserFactory
             Created = DateTime.UtcNow,
             Modified = DateTime.UtcNow,
             FirstName = faker.Person.FirstName,
-            LastName = faker.Person.LastName
+            LastName = faker.Person.LastName,
+            JobsDataConsent = true,
+            ImmigrationDataConsent = false
         });
 
         var externalIdentity = dbContext.ExternalIdentities.Add(new ExternalIdentity()

--- a/VirtualFinland.UsersAPI.IntegrationTests/Helpers/APIUserFactory.cs
+++ b/VirtualFinland.UsersAPI.IntegrationTests/Helpers/APIUserFactory.cs
@@ -19,7 +19,11 @@ public class APIUserFactory
             FirstName = faker.Person.FirstName,
             LastName = faker.Person.LastName,
             JobsDataConsent = true,
-            ImmigrationDataConsent = false
+            ImmigrationDataConsent = false,
+            NationalityISOCode = "FR",
+            CountryOfBirthISOCode = "FR",
+            ProfessionISCOCode = "4012",
+            NativeLanguageISOCode = "FR",
         });
 
         var externalIdentity = dbContext.ExternalIdentities.Add(new ExternalIdentity()

--- a/VirtualFinland.UsersAPI.IntegrationTests/Tests/Activities/User/UserTests.cs
+++ b/VirtualFinland.UsersAPI.IntegrationTests/Tests/Activities/User/UserTests.cs
@@ -26,7 +26,7 @@ public class UserTests : APITestBase
         var result = await handler.Handle(query, CancellationToken.None);
 
         // Assert
-        result.Should().Match<GetUser.User>(o => o.Id == dbEntities.user.Id && o.address == dbEntities.user.Address && o.FirstName == dbEntities.user.FirstName && o.LastName == dbEntities.user.LastName);
+        result.Should().Match<GetUser.User>(o => o.Id == dbEntities.user.Id && o.address == dbEntities.user.Address && o.FirstName == dbEntities.user.FirstName && o.LastName == dbEntities.user.LastName && o.ImmigrationDataConsent == dbEntities.user.ImmigrationDataConsent && o.JobsDataConsent == dbEntities.user.JobsDataConsent);
         
     }
     
@@ -36,7 +36,7 @@ public class UserTests : APITestBase
         // Arrange
         var dbEntities = await APIUserFactory.CreateAndGetLogInUser(_dbContext);
         var mockLogger = new Mock<ILogger<UpdateUser.Handler>>();
-        var command = new UpdateUser.Command("New FirstName", "New LastName", new List<string>(), new List<string>());
+        var command = new UpdateUser.Command("New FirstName", "New LastName", string.Empty, true, false, new List<string>(), new List<string>());
         command.SetAuth(dbEntities.externalIdentity.IdentityId, dbEntities.externalIdentity.Issuer);
         var handler = new UpdateUser.Handler(_dbContext, mockLogger.Object);
         
@@ -44,7 +44,7 @@ public class UserTests : APITestBase
         var result = await handler.Handle(command, CancellationToken.None);
 
         // Assert
-        result.Should().Match<UpdateUser.User>(o => o.Id == dbEntities.user.Id && o.FirstName == command.FirstName && o.LastName == command.LastName);
+        result.Should().Match<UpdateUser.User>(o => o.Id == dbEntities.user.Id && o.FirstName == command.FirstName && o.LastName == command.LastName && o.ImmigrationDataConsent == command.ImmigrationDataConsent && o.JobsDataConsent == command.JobsDataConsent);
         
     }
 }

--- a/VirtualFinland.UsersAPI.IntegrationTests/Tests/Activities/User/UserTests.cs
+++ b/VirtualFinland.UsersAPI.IntegrationTests/Tests/Activities/User/UserTests.cs
@@ -26,7 +26,14 @@ public class UserTests : APITestBase
         var result = await handler.Handle(query, CancellationToken.None);
 
         // Assert
-        result.Should().Match<GetUser.User>(o => o.Id == dbEntities.user.Id && o.address == dbEntities.user.Address && o.FirstName == dbEntities.user.FirstName && o.LastName == dbEntities.user.LastName && o.ImmigrationDataConsent == dbEntities.user.ImmigrationDataConsent && o.JobsDataConsent == dbEntities.user.JobsDataConsent);
+        result.Should()
+            .Match<GetUser.User>(o =>
+                o.Id == dbEntities.user.Id &&
+                o.address == dbEntities.user.Address &&
+                o.FirstName == dbEntities.user.FirstName &&
+                o.LastName == dbEntities.user.LastName &&
+                o.ImmigrationDataConsent == dbEntities.user.ImmigrationDataConsent &&
+                o.JobsDataConsent == dbEntities.user.JobsDataConsent);
         
     }
     
@@ -36,7 +43,7 @@ public class UserTests : APITestBase
         // Arrange
         var dbEntities = await APIUserFactory.CreateAndGetLogInUser(_dbContext);
         var mockLogger = new Mock<ILogger<UpdateUser.Handler>>();
-        var command = new UpdateUser.Command("New FirstName", "New LastName", string.Empty, true, false, new List<string>(), new List<string>());
+        var command = new UpdateUser.Command("New FirstName", "New LastName", string.Empty, true, false, "en", "en", "5001","en",new List<string>(), new List<string>());
         command.SetAuth(dbEntities.externalIdentity.IdentityId, dbEntities.externalIdentity.Issuer);
         var handler = new UpdateUser.Handler(_dbContext, mockLogger.Object);
         
@@ -44,7 +51,17 @@ public class UserTests : APITestBase
         var result = await handler.Handle(command, CancellationToken.None);
 
         // Assert
-        result.Should().Match<UpdateUser.User>(o => o.Id == dbEntities.user.Id && o.FirstName == command.FirstName && o.LastName == command.LastName && o.ImmigrationDataConsent == command.ImmigrationDataConsent && o.JobsDataConsent == command.JobsDataConsent);
+        result.Should()
+            .Match<UpdateUser.User>(o =>
+                o.Id == dbEntities.user.Id &&
+                o.FirstName == command.FirstName &&
+                o.LastName == command.LastName &&
+                o.ImmigrationDataConsent == command.ImmigrationDataConsent &&
+                o.JobsDataConsent == command.JobsDataConsent &&
+                o.NationalityISO == command.NationalityISO &&
+                o.NativeLanguageISO == command.NativeLanguageISO &&
+                o.ProfessionISCO == command.ProfessionISCO &&
+                o.CountryOfBirthISO == command.CountryOfBirthISO);
         
     }
 }


### PR DESCRIPTION
Added two new fields to allow the simulation of Application consents, in this case two of them:
* Jobs search app
* Immigration forms app

Added Docker local dev environment fixes:
* Retry logic for testbed openid configuration over internet, if fails 5 times kill the application
* Modified the ORM DB connection retry again, to try 5 time in 5 sec intervals
* Configured a docker-compose health check for the DB from the backend container to avoid situations where the DB is not ready when the backend starts
* Modified the docker build files to have two separate options and init script for x86 and arm, the dotnet publish functionality does not work out of the box with Apple M1 ARM CPU, need special build params