### PR TITLE
Added AWS Secret manager support

### DIFF
--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Configurations/AWSConfigurationManager.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Configurations/AWSConfigurationManager.cs
@@ -1,0 +1,21 @@
+using Amazon.SecretsManager;
+using Amazon.SecretsManager.Extensions.Caching;
+
+namespace VirtualFinland.UserAPI.Helpers.Configurations;
+
+public class AwsConfigurationManager
+{
+    private readonly AmazonSecretsManagerClient _amazonSecretsManagerClient;
+    private readonly SecretsManagerCache _secretsManagerCache;
+
+    public AwsConfigurationManager()
+    {
+        _amazonSecretsManagerClient = new AmazonSecretsManagerClient();
+        _secretsManagerCache = new SecretsManagerCache(_amazonSecretsManagerClient);
+    }
+
+    public async Task<string> GetSecretString(string? secretName)
+    {
+        return await _secretsManagerCache.GetSecretString(secretName);
+    }
+}

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/VirtualFinland.UsersAPI.csproj
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/VirtualFinland.UsersAPI.csproj
@@ -14,6 +14,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.3.1" />
+        <PackageReference Include="AWSSDK.SecretsManager.Caching" Version="1.0.5" />
         <PackageReference Include="FluentValidation" Version="11.2.2" />
         <PackageReference Include="ISO3166" Version="1.0.4" />
         <PackageReference Include="MediatR" Version="11.0.0" />


### PR DESCRIPTION
Pulumi Configuration to add the RDS DB Connection string to AWS Secret manager.

Added server support for retrieving the secret from AWS secret manager if available.

The secret is retrieved only when the lambda function starts, subsequent requests do not invoke the secret manager.