### PR TITLE
Vfd 114 paivitetaan users api sovellus tukemaan paivitettya profiilidata maarittelya

### DIFF
--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/GetUser.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/GetUser.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Swashbuckle.AspNetCore.Annotations;
 using VirtualFinland.UserAPI.Data;
 using VirtualFinland.UserAPI.Helpers.Swagger;
+using VirtualFinland.UserAPI.Models.UsersDatabase;
 
 namespace VirtualFinland.UserAPI.Activities.User.Operations;
 
@@ -52,6 +53,9 @@ public static class GetUser
                 dbUser.FirstName,
                 dbUser.LastName,
                 dbUser.Address,
+                string.Empty, // TODO: Return actual data
+                string.Empty,
+                string.Empty,
                 dbUserDefaultSearchProfile?.JobTitles,
                 dbUserDefaultSearchProfile?.Regions,
                 dbUser.Created,
@@ -72,6 +76,9 @@ public static class GetUser
         string? FirstName,
         string? LastName,
         string? Address,
+        string? ZipCode,
+        string? City,
+        string? Country,
         List<string>? JobTitles,
         List<string>? Regions,
         DateTime Created,
@@ -82,7 +89,7 @@ public static class GetUser
         string? NativeLanguageCode,
         string? OccupationCode,
         string? CitizenshipCode,
-        string? Gender,
+        Gender? Gender,
         DateTime? DateOfBirth);
     
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/GetUser.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/GetUser.cs
@@ -52,10 +52,12 @@ public static class GetUser
             return new User(dbUser.Id,
                 dbUser.FirstName,
                 dbUser.LastName,
-                dbUser.Address,
-                string.Empty, // TODO: Return actual data
-                string.Empty,
-                string.Empty,
+                new Address(
+                    dbUser.Address,
+                    string.Empty, // TODO: Return actual data
+                    string.Empty,
+                    string.Empty
+                ),
                 dbUserDefaultSearchProfile?.JobTitles,
                 dbUserDefaultSearchProfile?.Regions,
                 dbUser.Created,
@@ -75,10 +77,7 @@ public static class GetUser
     public record User(Guid Id,
         string? FirstName,
         string? LastName,
-        string? Address,
-        string? ZipCode,
-        string? City,
-        string? Country,
+        Address? Address,
         List<string>? JobTitles,
         List<string>? Regions,
         DateTime Created,
@@ -92,4 +91,10 @@ public static class GetUser
         Gender? Gender,
         DateTime? DateOfBirth);
     
+    public record Address(
+        string? StreetAddress,
+        string? ZipCode,
+        string? City,
+        string? Country
+    );
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/GetUser.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/GetUser.cs
@@ -53,7 +53,7 @@ public static class GetUser
                 dbUser.FirstName,
                 dbUser.LastName,
                 new Address(
-                    dbUser.Address,
+                    dbUser.StreetAddress,
                     string.Empty, // TODO: Return actual data
                     string.Empty,
                     string.Empty

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/GetUser.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/GetUser.cs
@@ -54,9 +54,9 @@ public static class GetUser
                 dbUser.LastName,
                 new Address(
                     dbUser.StreetAddress,
-                    string.Empty, // TODO: Return actual data
-                    string.Empty,
-                    string.Empty
+                    dbUser.ZipCode,
+                    dbUser.City,
+                    dbUser.Country
                 ),
                 dbUserDefaultSearchProfile?.JobTitles,
                 dbUserDefaultSearchProfile?.Regions,

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/UpdateUser.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/UpdateUser.cs
@@ -132,9 +132,9 @@ public static class UpdateUser
                     dbUser.LastName,
                     new Address(
                         dbUser.StreetAddress,
-                        string.Empty, // TODO: Return actual data
-                        string.Empty,
-                        string.Empty
+                        dbUser.ZipCode, // TODO: Return actual data
+                        dbUser.City,
+                        dbUser.Country
                     ),
                     dbUserDefaultSearchProfile.JobTitles,
                     dbUserDefaultSearchProfile.Regions,

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/UpdateUser.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/UpdateUser.cs
@@ -131,7 +131,7 @@ public static class UpdateUser
                     dbUser.FirstName,
                     dbUser.LastName,
                     new Address(
-                        dbUser.Address,
+                        dbUser.StreetAddress,
                         string.Empty, // TODO: Return actual data
                         string.Empty,
                         string.Empty
@@ -165,7 +165,7 @@ public static class UpdateUser
 
                 dbUser.FirstName = request.FirstName ?? dbUser.FirstName;
                 dbUser.LastName = request.LastName ?? dbUser.LastName;
-                dbUser.Address = request.Address ?? dbUser.Address;
+                dbUser.StreetAddress = request.Address ?? dbUser.StreetAddress;
                 dbUser.Modified = DateTime.UtcNow;
                 dbUser.ImmigrationDataConsent = request.ImmigrationDataConsent ?? dbUser.ImmigrationDataConsent;
                 dbUser.JobsDataConsent = request.JobsDataConsent ?? dbUser.JobsDataConsent;

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/UpdateUser.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/UpdateUser.cs
@@ -36,14 +36,15 @@ public static class UpdateUser
         public List<string>? JobTitles { get; }
         public List<string>? Regions { get; }
         
-        public string? Gender { get; }
+        public Gender? Gender { get; }
         
         public DateTime? DateOfBirth { get; }
         
         [SwaggerIgnore]
         public Guid? UserId { get; private set; }
         
-        public Command(string? firstName,
+        public Command(
+            string? firstName,
             string? lastName,
             string? address,
             bool? jobsDataConsent,
@@ -54,7 +55,7 @@ public static class UpdateUser
             string? citizenshipCode,
             List<string>? jobTitles,
             List<string>? regions,
-            string? gender,
+            Gender? gender,
             DateTime? dateOfBirth)
         {
             this.FirstName = firstName;
@@ -85,12 +86,12 @@ public static class UpdateUser
             RuleFor(command => command.UserId).NotNull().NotEmpty();
             RuleFor(command => command.FirstName).MaximumLength(255);
             RuleFor(command => command.LastName).MaximumLength(255);
-            RuleFor(command => command.Address).MaximumLength(512);
+            RuleFor(command => command.Address).MaximumLength(255);
             RuleFor(command => command.CitizenshipCode).MaximumLength(10);
             RuleFor(command => command.OccupationCode).MaximumLength(10);
             RuleFor(command => command.NativeLanguageCode).MaximumLength(10);
             RuleFor(command => command.CountryOfBirthCode).MaximumLength(10);
-            RuleFor(command => command.Gender).MaximumLength(10);
+            RuleFor(command => command.Gender).IsInEnum();
         }
     }
     
@@ -125,10 +126,14 @@ public static class UpdateUser
                 
                 _logger.LogDebug("User data updated for user: {DbUserId}", dbUser.Id);
 
-                return new User(dbUser.Id,
+                return new User(
+                    dbUser.Id,
                     dbUser.FirstName,
                     dbUser.LastName,
                     dbUser.Address,
+                    string.Empty, // TODO: Return actual data
+                    string.Empty,
+                    string.Empty,
                     dbUserDefaultSearchProfile.JobTitles,
                     dbUserDefaultSearchProfile.Regions,
                     dbUser.Created,
@@ -265,6 +270,9 @@ public static class UpdateUser
         string? FirstName,
         string? LastName,
         string? Address,
+        string? ZipCode,
+        string? City,
+        string? Country,
         List<string>? JobTitles,
         List<string>? Regions,
         DateTime Created,
@@ -275,6 +283,6 @@ public static class UpdateUser
         string? NativeLanguageCode,
         string? OccupationCode,
         string? CitizenshipCode,
-        string? Gender,
+        Gender? Gender,
         DateTime? DateOfBirth);
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/UpdateUser.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/UpdateUser.cs
@@ -130,10 +130,12 @@ public static class UpdateUser
                     dbUser.Id,
                     dbUser.FirstName,
                     dbUser.LastName,
-                    dbUser.Address,
-                    string.Empty, // TODO: Return actual data
-                    string.Empty,
-                    string.Empty,
+                    new Address(
+                        dbUser.Address,
+                        string.Empty, // TODO: Return actual data
+                        string.Empty,
+                        string.Empty
+                    ),
                     dbUserDefaultSearchProfile.JobTitles,
                     dbUserDefaultSearchProfile.Regions,
                     dbUser.Created,
@@ -269,10 +271,7 @@ public static class UpdateUser
     public record User(Guid Id,
         string? FirstName,
         string? LastName,
-        string? Address,
-        string? ZipCode,
-        string? City,
-        string? Country,
+        Address? Address,
         List<string>? JobTitles,
         List<string>? Regions,
         DateTime Created,
@@ -285,4 +284,11 @@ public static class UpdateUser
         string? CitizenshipCode,
         Gender? Gender,
         DateTime? DateOfBirth);
+    
+    public record Address(
+        string? StreetAddress,
+        string? ZipCode,
+        string? City,
+        string? Country
+    );
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Data/UsersDBContext.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Data/UsersDBContext.cs
@@ -59,6 +59,8 @@ public class UsersDbContext : DbContext
             Modified = DateTime.UtcNow
         });
 
+        modelBuilder.Entity<User>().Property(u => u.Gender).HasConversion<string>();
+
         modelBuilder.Entity<ExternalIdentity>().HasData(new ExternalIdentity()
         {
             Id = Guid.NewGuid(),

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20221122072344_GenderAndAddressDefinition.Designer.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20221122072344_GenderAndAddressDefinition.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using VirtualFinland.UserAPI.Data;
@@ -12,9 +13,10 @@ using VirtualFinland.UserAPI.Data;
 namespace VirtualFinland.UserAPI.Migrations
 {
     [DbContext(typeof(UsersDbContext))]
-    partial class UsersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221122072344_GenderAndAddressDefinition")]
+    partial class GenderAndAddressDefinition
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20221122072344_GenderAndAddressDefinition.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20221122072344_GenderAndAddressDefinition.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VirtualFinland.UserAPI.Migrations
+{
+    public partial class GenderAndAddressDefinition : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "ExternalIdentities",
+                keyColumn: "Id",
+                keyValue: new Guid("1bcf54d5-7d87-4d79-973d-9fec4e2b626b"));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Gender",
+                table: "Users",
+                type: "text",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(10)",
+                oldMaxLength: 10,
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "City",
+                table: "Users",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Country",
+                table: "Users",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ZipCode",
+                table: "Users",
+                type: "character varying(5)",
+                maxLength: 5,
+                nullable: true);
+
+            migrationBuilder.InsertData(
+                table: "ExternalIdentities",
+                columns: new[] { "Id", "Created", "IdentityId", "Issuer", "Modified", "UserId" },
+                values: new object[] { new Guid("981cecb2-d916-49e7-b194-a9d0e81bf1b2"), new DateTime(2022, 11, 22, 7, 23, 44, 435, DateTimeKind.Utc).AddTicks(4050), "1766fb5f-c867-45e3-90ee-9b6fba5d2d80", "20ca085a-64e1-4787-ae5f-1a82049cb941", new DateTime(2022, 11, 22, 7, 23, 44, 435, DateTimeKind.Utc).AddTicks(4050), new Guid("5a8af4b4-8cb4-44ac-8291-010614601719") });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: new Guid("5a8af4b4-8cb4-44ac-8291-010614601719"),
+                columns: new[] { "Created", "Gender", "Modified" },
+                values: new object[] { new DateTime(2022, 11, 22, 7, 23, 44, 435, DateTimeKind.Utc).AddTicks(3620), "0", new DateTime(2022, 11, 22, 7, 23, 44, 435, DateTimeKind.Utc).AddTicks(3620) });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "ExternalIdentities",
+                keyColumn: "Id",
+                keyValue: new Guid("981cecb2-d916-49e7-b194-a9d0e81bf1b2"));
+
+            migrationBuilder.DropColumn(
+                name: "City",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "Country",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "ZipCode",
+                table: "Users");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Gender",
+                table: "Users",
+                type: "character varying(10)",
+                maxLength: 10,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.InsertData(
+                table: "ExternalIdentities",
+                columns: new[] { "Id", "Created", "IdentityId", "Issuer", "Modified", "UserId" },
+                values: new object[] { new Guid("1bcf54d5-7d87-4d79-973d-9fec4e2b626b"), new DateTime(2022, 11, 10, 9, 31, 24, 968, DateTimeKind.Utc).AddTicks(5420), "709e02eb-9215-4665-890b-9b508e9cc909", "3ab418ba-8bd0-4072-b74e-33b8eed26d9b", new DateTime(2022, 11, 10, 9, 31, 24, 968, DateTimeKind.Utc).AddTicks(5420), new Guid("5a8af4b4-8cb4-44ac-8291-010614601719") });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: new Guid("5a8af4b4-8cb4-44ac-8291-010614601719"),
+                columns: new[] { "Created", "Gender", "Modified" },
+                values: new object[] { new DateTime(2022, 11, 10, 9, 31, 24, 968, DateTimeKind.Utc).AddTicks(5300), null, new DateTime(2022, 11, 10, 9, 31, 24, 968, DateTimeKind.Utc).AddTicks(5300) });
+        }
+    }
+}

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20221123071509_RenameAddressToStreetAddress.Designer.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20221123071509_RenameAddressToStreetAddress.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using VirtualFinland.UserAPI.Data;
@@ -12,9 +13,10 @@ using VirtualFinland.UserAPI.Data;
 namespace VirtualFinland.UserAPI.Migrations
 {
     [DbContext(typeof(UsersDbContext))]
-    partial class UsersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221123071509_RenameAddressToStreetAddress")]
+    partial class RenameAddressToStreetAddress
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20221123071509_RenameAddressToStreetAddress.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20221123071509_RenameAddressToStreetAddress.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VirtualFinland.UserAPI.Migrations
+{
+    public partial class RenameAddressToStreetAddress : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "ExternalIdentities",
+                keyColumn: "Id",
+                keyValue: new Guid("981cecb2-d916-49e7-b194-a9d0e81bf1b2"));
+
+            migrationBuilder.RenameColumn(
+                name: "Address",
+                table: "Users",
+                newName: "StreetAddress");
+
+            migrationBuilder.InsertData(
+                table: "ExternalIdentities",
+                columns: new[] { "Id", "Created", "IdentityId", "Issuer", "Modified", "UserId" },
+                values: new object[] { new Guid("9ed28e82-6cb9-4c48-a27c-603c5a97221f"), new DateTime(2022, 11, 23, 7, 15, 9, 238, DateTimeKind.Utc).AddTicks(4460), "a8f51b88-af6b-4a95-b2d8-da62e0fb4f65", "15b205f4-98bc-491f-8616-ce66043ee7f6", new DateTime(2022, 11, 23, 7, 15, 9, 238, DateTimeKind.Utc).AddTicks(4460), new Guid("5a8af4b4-8cb4-44ac-8291-010614601719") });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: new Guid("5a8af4b4-8cb4-44ac-8291-010614601719"),
+                columns: new[] { "Created", "Modified" },
+                values: new object[] { new DateTime(2022, 11, 23, 7, 15, 9, 238, DateTimeKind.Utc).AddTicks(4010), new DateTime(2022, 11, 23, 7, 15, 9, 238, DateTimeKind.Utc).AddTicks(4010) });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "ExternalIdentities",
+                keyColumn: "Id",
+                keyValue: new Guid("9ed28e82-6cb9-4c48-a27c-603c5a97221f"));
+
+            migrationBuilder.RenameColumn(
+                name: "StreetAddress",
+                table: "Users",
+                newName: "Address");
+
+            migrationBuilder.InsertData(
+                table: "ExternalIdentities",
+                columns: new[] { "Id", "Created", "IdentityId", "Issuer", "Modified", "UserId" },
+                values: new object[] { new Guid("981cecb2-d916-49e7-b194-a9d0e81bf1b2"), new DateTime(2022, 11, 22, 7, 23, 44, 435, DateTimeKind.Utc).AddTicks(4050), "1766fb5f-c867-45e3-90ee-9b6fba5d2d80", "20ca085a-64e1-4787-ae5f-1a82049cb941", new DateTime(2022, 11, 22, 7, 23, 44, 435, DateTimeKind.Utc).AddTicks(4050), new Guid("5a8af4b4-8cb4-44ac-8291-010614601719") });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: new Guid("5a8af4b4-8cb4-44ac-8291-010614601719"),
+                columns: new[] { "Created", "Modified" },
+                values: new object[] { new DateTime(2022, 11, 22, 7, 23, 44, 435, DateTimeKind.Utc).AddTicks(3620), new DateTime(2022, 11, 22, 7, 23, 44, 435, DateTimeKind.Utc).AddTicks(3620) });
+        }
+    }
+}

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/UsersDatabase/User.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/UsersDatabase/User.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 
 namespace VirtualFinland.UserAPI.Models.UsersDatabase;
 
@@ -20,14 +21,22 @@ public class User : IEntity
     [MaxLength(512)]
     public string? Address { get; set; }
     
+    [MaxLength(5)]
+    public string? ZipCode { get; set; }
+ 
+    [MaxLength(512)]
+    public string? City { get; set; }
+    
+    [MaxLength(512)]
+    public string? Country { get; set; }
+    
     public bool ImmigrationDataConsent { get; set; }
     
     public bool JobsDataConsent { get; set; }
     
     public DateOnly? DateOfBirth { get; set; }
     
-    [MaxLength(10)]
-    public string? Gender { get; set; }
+    public Gender Gender { get; set; }
     
     [MaxLength(10)]
     public string? CountryOfBirthCode { get; set; }
@@ -40,4 +49,12 @@ public class User : IEntity
     
     [MaxLength(10)]
     public string? CitizenshipCode { get; set; }
+}
+
+public enum Gender
+{
+    [JsonPropertyName("MALE")]
+    Male = 1,
+    [JsonPropertyName("FEMALE")]
+    Female = 2
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/UsersDatabase/User.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/UsersDatabase/User.cs
@@ -19,7 +19,7 @@ public class User : IEntity
     public string? LastName { get; set; }
     
     [MaxLength(512)]
-    public string? Address { get; set; }
+    public string? StreetAddress { get; set; }
     
     [MaxLength(5)]
     public string? ZipCode { get; set; }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/UsersDatabase/User.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/UsersDatabase/User.cs
@@ -51,10 +51,11 @@ public class User : IEntity
     public string? CitizenshipCode { get; set; }
 }
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum Gender
 {
-    [JsonPropertyName("MALE")]
+    [JsonPropertyName("Male")]
     Male = 1,
-    [JsonPropertyName("FEMALE")]
+    [JsonPropertyName("Female")]
     Female = 2
 }

--- a/VirtualFinland.UsersAPI.UnitTests/Helpers/APIUserFactory.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Helpers/APIUserFactory.cs
@@ -1,20 +1,22 @@
 using Bogus;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using VirtualFinland.UserAPI.Data;
-using VirtualFinland.UserAPI.Models;
 using VirtualFinland.UserAPI.Models.UsersDatabase;
 
 namespace VirtualFinland.UsersAPI.UnitTests.Helpers;
 
 public class APIUserFactory
 {
-    public async static Task<(User user, ExternalIdentity externalIdentity)> CreateAndGetLogInUser(UsersDbContext dbContext)
+    public static async Task<(User user, ExternalIdentity externalIdentity)> CreateAndGetLogInUser(
+        UsersDbContext dbContext)
     {
-        var faker = new Faker("en");
-        
-        var dbUser = dbContext.Users.Add(new User()
+        var faker = new Faker();
+
+        var dbUser = dbContext.Users.Add(new User
         {
-            Address = faker.Address.FullAddress(),
+            Address = faker.Address.StreetAddress(),
+            ZipCode = faker.Address.ZipCode(),
+            City = faker.Address.City(),
+            Country = faker.Address.Country(),
             Created = DateTime.UtcNow,
             Modified = DateTime.UtcNow,
             FirstName = faker.Person.FirstName,
@@ -25,11 +27,11 @@ public class APIUserFactory
             CountryOfBirthCode = "FR",
             OccupationCode = "4012",
             NativeLanguageCode = "FR",
-            Gender = "1",
+            Gender = Gender.Male,
             DateOfBirth = DateOnly.FromDateTime(DateTime.Now)
         });
 
-        var externalIdentity = dbContext.ExternalIdentities.Add(new ExternalIdentity()
+        var externalIdentity = dbContext.ExternalIdentities.Add(new ExternalIdentity
         {
             Created = DateTime.UtcNow,
             Modified = DateTime.UtcNow,

--- a/VirtualFinland.UsersAPI.UnitTests/Helpers/APIUserFactory.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Helpers/APIUserFactory.cs
@@ -13,7 +13,7 @@ public class APIUserFactory
 
         var dbUser = dbContext.Users.Add(new User
         {
-            Address = faker.Address.StreetAddress(),
+            StreetAddress = faker.Address.StreetAddress(),
             ZipCode = faker.Address.ZipCode(),
             City = faker.Address.City(),
             Country = faker.Address.Country(),

--- a/VirtualFinland.UsersAPI.UnitTests/Mocks/MockCountriesRepository.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Mocks/MockCountriesRepository.cs
@@ -3,7 +3,7 @@ using VirtualFinland.UserAPI.Models.Repositories;
 
 namespace VirtualFinland.UsersAPI.UnitTests.Mocks;
 
-public class MockContriesRepository : ICountriesRepository
+public class MockCountriesRepository : ICountriesRepository
 {
 
     public Task<List<Country>> GetAllCountries()

--- a/VirtualFinland.UsersAPI.UnitTests/Tests/Activities/User/UpdateUserCommandBuilder.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Tests/Activities/User/UpdateUserCommandBuilder.cs
@@ -1,0 +1,118 @@
+using VirtualFinland.UserAPI.Activities.User.Operations;
+using VirtualFinland.UserAPI.Models.UsersDatabase;
+
+namespace VirtualFinland.UsersAPI.UnitTests.Tests.Activities.User;
+
+public class UpdateUserCommandBuilder
+{
+    private string _firstName = "FirstName";
+    private string _lastName = "LastName";
+    private string _address = "Address";
+    private bool? _jobsDataConsent = true;
+    private bool? _immigrationDataConsent = true;
+    private string _countryOfBirthCode = "fi";
+    private string _nativeLanguageCode = "fi-FI";
+    private string _occupationCode = "01";
+    private string _citizenshipCode = "fi";
+    private List<string>? _jobTitles = new() { "programmer" };
+    private List<string>? _regions = new() { "Southern-Finland" };
+    private Gender _gender = Gender.Male;
+    private DateTime? _dateOfBirth = new(2022, 01,01);
+
+    public UpdateUserCommandBuilder WithFirstName(string value)
+    {
+        _firstName = value;
+        return this;
+    }
+
+    public UpdateUserCommandBuilder WithLastName(string value)
+    {
+        _lastName = value;
+        return this;
+    }
+
+    public UpdateUserCommandBuilder WithAddress(string value)
+    {
+        _address = value;
+        return this;
+    }
+
+    public UpdateUserCommandBuilder WithJobsDataConsent(bool? value)
+    {
+        _jobsDataConsent = value;
+        return this;
+    }
+
+    public UpdateUserCommandBuilder WithImmigrationDataConsent(bool? value)
+    {
+        _immigrationDataConsent = value;
+        return this;
+    }
+
+    public UpdateUserCommandBuilder WithCountryOfBirthCode(string value)
+    {
+        _countryOfBirthCode = value;
+        return this;
+    }
+
+    public UpdateUserCommandBuilder WithNativeLanguageCode(string value)
+    {
+        _nativeLanguageCode = value;
+        return this;
+    }
+
+    public UpdateUserCommandBuilder WithOccupationCode(string value)
+    {
+        _occupationCode = value;
+        return this;
+    }
+
+    public UpdateUserCommandBuilder WithCitizenshipCode(string value)
+    {
+        _citizenshipCode = value;
+        return this;
+    }
+
+    public UpdateUserCommandBuilder WithJobTitles(List<string>? value)
+    {
+        _jobTitles = value;
+        return this;
+    }
+
+    public UpdateUserCommandBuilder WithRegions(List<string>? value)
+    {
+        _regions = value;
+        return this;
+    }
+
+    public UpdateUserCommandBuilder WithGender(Gender value)
+    {
+        _gender = value;
+        return this;
+    }
+
+    public UpdateUserCommandBuilder WithDateOfBirth(DateTime? value)
+    {
+        _dateOfBirth = value;
+        return this;
+    }
+
+    public UpdateUser.Command Build()
+    {
+        return new UpdateUser.Command(
+            _firstName,
+            _lastName,
+            _address,
+            _jobsDataConsent,
+            _immigrationDataConsent,
+            _countryOfBirthCode,
+            _nativeLanguageCode,
+            _occupationCode,
+            _citizenshipCode,
+            _jobTitles,
+            _regions,
+            _gender,
+            _dateOfBirth
+        );
+    }
+}

--- a/VirtualFinland.UsersAPI.UnitTests/Tests/Activities/User/UserTests.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Tests/Activities/User/UserTests.cs
@@ -59,7 +59,7 @@ public class UserTests : APITestBase
         var dbEntities = await APIUserFactory.CreateAndGetLogInUser(_dbContext);
         var mockLogger = new Mock<ILogger<UpdateUser.Handler>>();
         var occupationRepository = new MockOccupationsRepository();
-        var countryRepository = new MockContriesRepository();
+        var countryRepository = new MockCountriesRepository();
         var languageRepository = new LanguageRepository();
         
         var command = new UpdateUser.Command("New FirstName", "New LastName", string.Empty, true, false, "fi", "fi-FI", "01","fi",new List<string>(), new List<string>(), "1", DateTime.Now);
@@ -92,7 +92,7 @@ public class UserTests : APITestBase
         var dbEntities = await APIUserFactory.CreateAndGetLogInUser(_dbContext);
         var mockLogger = new Mock<ILogger<UpdateUser.Handler>>();
         var occupationRepository = new MockOccupationsRepository();
-        var countryRepository = new MockContriesRepository();
+        var countryRepository = new MockCountriesRepository();
         var languageRepository = new LanguageRepository();
         
         var command = new UpdateUser.Command(null, null, null, null, null, null, null, null,"not a code",null, null, null, null);
@@ -113,7 +113,7 @@ public class UserTests : APITestBase
         var dbEntities = await APIUserFactory.CreateAndGetLogInUser(_dbContext);
         var mockLogger = new Mock<ILogger<UpdateUser.Handler>>();
         var occupationRepository = new MockOccupationsRepository();
-        var countryRepository = new MockContriesRepository();
+        var countryRepository = new MockCountriesRepository();
         var languageRepository = new LanguageRepository();
         
         var command = new UpdateUser.Command(null, null, null, null, null, "not a code", null, null,null,null, null, null, null);
@@ -134,7 +134,7 @@ public class UserTests : APITestBase
         var dbEntities = await APIUserFactory.CreateAndGetLogInUser(_dbContext);
         var mockLogger = new Mock<ILogger<UpdateUser.Handler>>();
         var occupationRepository = new MockOccupationsRepository();
-        var countryRepository = new MockContriesRepository();
+        var countryRepository = new MockCountriesRepository();
         var languageRepository = new LanguageRepository();
         
         var command = new UpdateUser.Command(null, null, null, null, null, null, "not a code", null,null,null, null, null, null);
@@ -155,7 +155,7 @@ public class UserTests : APITestBase
         var dbEntities = await APIUserFactory.CreateAndGetLogInUser(_dbContext);
         var mockLogger = new Mock<ILogger<UpdateUser.Handler>>();
         var occupationRepository = new MockOccupationsRepository();
-        var countryRepository = new MockContriesRepository();
+        var countryRepository = new MockCountriesRepository();
         var languageRepository = new LanguageRepository();
         
         var command = new UpdateUser.Command(null, null, null, null, null, null, null, "not a code",null,null, null, null, null);
@@ -175,7 +175,7 @@ public class UserTests : APITestBase
         // Arrange
         var mockLogger = new Mock<ILogger<UpdateUser.Handler>>();
         var occupationRepository = new MockOccupationsRepository();
-        var countryRepository = new MockContriesRepository();
+        var countryRepository = new MockCountriesRepository();
         var languageRepository = new LanguageRepository();
         
         var command = new UpdateUser.Command(null, null, null, null, null, null, null, "not a code",null,null, null, null, null);

--- a/VirtualFinland.UsersAPI.UnitTests/Tests/Activities/User/UserTests.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Tests/Activities/User/UserTests.cs
@@ -30,7 +30,7 @@ public class UserTests : APITestBase
             .Match<GetUser.User>(o =>
                 o.DateOfBirth != null &&
                 o.Id == dbEntities.user.Id &&
-                o.Address!.StreetAddress == dbEntities.user.Address &&
+                o.Address!.StreetAddress == dbEntities.user.StreetAddress &&
                 o.FirstName == dbEntities.user.FirstName &&
                 o.LastName == dbEntities.user.LastName &&
                 o.ImmigrationDataConsent == dbEntities.user.ImmigrationDataConsent &&

--- a/VirtualFinland.UsersAPI.UnitTests/Tests/Activities/User/UserTests.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Tests/Activities/User/UserTests.cs
@@ -30,7 +30,7 @@ public class UserTests : APITestBase
             .Match<GetUser.User>(o =>
                 o.DateOfBirth != null &&
                 o.Id == dbEntities.user.Id &&
-                o.Address == dbEntities.user.Address &&
+                o.Address!.StreetAddress == dbEntities.user.Address &&
                 o.FirstName == dbEntities.user.FirstName &&
                 o.LastName == dbEntities.user.LastName &&
                 o.ImmigrationDataConsent == dbEntities.user.ImmigrationDataConsent &&

--- a/VirtualFinland.UsersAPI.UnitTests/Tests/Activities/User/UserTests.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Tests/Activities/User/UserTests.cs
@@ -1,28 +1,20 @@
-using System.ComponentModel.DataAnnotations;
-using Bogus;
-using Microsoft.EntityFrameworkCore;
-using VirtualFinland.UserAPI.Activities.User.Operations;
-using VirtualFinland.UserAPI.Data;
 using FluentAssertions;
 using FluentValidation.TestHelper;
 using Microsoft.Extensions.Logging;
 using Moq;
-using VirtualFinland.UserAPI.Activities.Identity.Operations;
+using VirtualFinland.UserAPI.Activities.User.Operations;
 using VirtualFinland.UserAPI.Data.Repositories;
 using VirtualFinland.UserAPI.Exceptions;
-using VirtualFinland.UserAPI.Models;
+using VirtualFinland.UserAPI.Models.UsersDatabase;
 using VirtualFinland.UsersAPI.UnitTests.Helpers;
 using VirtualFinland.UsersAPI.UnitTests.Mocks;
-using UpdateUser = VirtualFinland.UserAPI.Activities.User.Operations.UpdateUser;
-using ValidationResult = System.ComponentModel.DataAnnotations.ValidationResult;
-
 
 namespace VirtualFinland.UsersAPI.UnitTests.Tests.Activities.User;
 
 public class UserTests : APITestBase
 {
     [Fact]
-    public async void Should_GetUserAsync()
+    public async Task Should_GetUserAsync()
     {
         // Arrange
         var dbEntities = await APIUserFactory.CreateAndGetLogInUser(_dbContext);
@@ -53,7 +45,7 @@ public class UserTests : APITestBase
     }
     
     [Fact]
-    public async void Should_UpdateUserAsync()
+    public async Task Should_UpdateUserAsync()
     {
         // Arrange
         var dbEntities = await APIUserFactory.CreateAndGetLogInUser(_dbContext);
@@ -61,13 +53,12 @@ public class UserTests : APITestBase
         var occupationRepository = new MockOccupationsRepository();
         var countryRepository = new MockCountriesRepository();
         var languageRepository = new LanguageRepository();
-        
-        var command = new UpdateUser.Command("New FirstName", "New LastName", string.Empty, true, false, "fi", "fi-FI", "01","fi",new List<string>(), new List<string>(), "1", DateTime.Now);
+        var command = new UpdateUserCommandBuilder().Build();
         command.SetAuth(dbEntities.user.Id);
-        var handler = new UpdateUser.Handler(_dbContext, mockLogger.Object, languageRepository, countryRepository, occupationRepository);
+        var sut = new UpdateUser.Handler(_dbContext, mockLogger.Object, languageRepository, countryRepository, occupationRepository);
         
         // Act
-        var result = await handler.Handle(command, CancellationToken.None);
+        var result = await sut.Handle(command, CancellationToken.None);
 
         // Assert
         result.Should()
@@ -86,7 +77,7 @@ public class UserTests : APITestBase
     }
     
     [Fact]
-    public async void Should_FailUpdateUserNationalityCheckAsync()
+    public async Task Should_FailUpdateUserNationalityCheckAsync()
     {
         // Arrange
         var dbEntities = await APIUserFactory.CreateAndGetLogInUser(_dbContext);
@@ -94,20 +85,19 @@ public class UserTests : APITestBase
         var occupationRepository = new MockOccupationsRepository();
         var countryRepository = new MockCountriesRepository();
         var languageRepository = new LanguageRepository();
-        
-        var command = new UpdateUser.Command(null, null, null, null, null, null, null, null,"not a code",null, null, null, null);
+        var command = new UpdateUserCommandBuilder().WithCitizenshipCode("not a code").Build();
         command.SetAuth(dbEntities.user.Id);
-        var handler = new UpdateUser.Handler(_dbContext, mockLogger.Object, languageRepository, countryRepository, occupationRepository);
+        var sut = new UpdateUser.Handler(_dbContext, mockLogger.Object, languageRepository, countryRepository, occupationRepository);
         
         // Act
-        var act = () => handler.Handle(command, CancellationToken.None);
+        var act = () => sut.Handle(command, CancellationToken.None);
 
         // Assert
         await act.Should().ThrowAsync<BadRequestException>();
     }
     
     [Fact]
-    public async void Should_FailUpdateUserCountryOfBirthAsync()
+    public async Task Should_FailUpdateUserCountryOfBirthAsync()
     {
         // Arrange
         var dbEntities = await APIUserFactory.CreateAndGetLogInUser(_dbContext);
@@ -115,20 +105,19 @@ public class UserTests : APITestBase
         var occupationRepository = new MockOccupationsRepository();
         var countryRepository = new MockCountriesRepository();
         var languageRepository = new LanguageRepository();
-        
-        var command = new UpdateUser.Command(null, null, null, null, null, "not a code", null, null,null,null, null, null, null);
+        var command = new UpdateUserCommandBuilder().WithCountryOfBirthCode("not a code").Build();
         command.SetAuth(dbEntities.user.Id);
-        var handler = new UpdateUser.Handler(_dbContext, mockLogger.Object, languageRepository, countryRepository, occupationRepository);
+        var sut = new UpdateUser.Handler(_dbContext, mockLogger.Object, languageRepository, countryRepository, occupationRepository);
         
         // Act
-        var act = () => handler.Handle(command, CancellationToken.None);
+        var act = () => sut.Handle(command, CancellationToken.None);
 
         // Assert
         await act.Should().ThrowAsync<BadRequestException>();
     }
     
     [Fact]
-    public async void Should_FailUpdateUserNativeLanguageCodeAsync()
+    public async Task Should_FailUpdateUserNativeLanguageCodeAsync()
     {
         // Arrange
         var dbEntities = await APIUserFactory.CreateAndGetLogInUser(_dbContext);
@@ -136,20 +125,19 @@ public class UserTests : APITestBase
         var occupationRepository = new MockOccupationsRepository();
         var countryRepository = new MockCountriesRepository();
         var languageRepository = new LanguageRepository();
-        
-        var command = new UpdateUser.Command(null, null, null, null, null, null, "not a code", null,null,null, null, null, null);
+        var command = new UpdateUserCommandBuilder().WithNativeLanguageCode("not a code").Build();
         command.SetAuth(dbEntities.user.Id);
-        var handler = new UpdateUser.Handler(_dbContext, mockLogger.Object, languageRepository, countryRepository, occupationRepository);
+        var sut = new UpdateUser.Handler(_dbContext, mockLogger.Object, languageRepository, countryRepository, occupationRepository);
         
         // Act
-        var act = () => handler.Handle(command, CancellationToken.None);
+        var act = () => sut.Handle(command, CancellationToken.None);
 
         // Assert
         await act.Should().ThrowAsync<BadRequestException>();
     }
     
     [Fact]
-    public async void Should_FailUpdateUserOccupationCodeAsync()
+    public async Task Should_FailUpdateUserOccupationCodeAsync()
     {
         // Arrange
         var dbEntities = await APIUserFactory.CreateAndGetLogInUser(_dbContext);
@@ -157,49 +145,62 @@ public class UserTests : APITestBase
         var occupationRepository = new MockOccupationsRepository();
         var countryRepository = new MockCountriesRepository();
         var languageRepository = new LanguageRepository();
-        
-        var command = new UpdateUser.Command(null, null, null, null, null, null, null, "not a code",null,null, null, null, null);
+        var command = new UpdateUserCommandBuilder().WithOccupationCode("not a code").Build();
         command.SetAuth(dbEntities.user.Id);
-        var handler = new UpdateUser.Handler(_dbContext, mockLogger.Object, languageRepository, countryRepository, occupationRepository);
+        var sut = new UpdateUser.Handler(_dbContext, mockLogger.Object, languageRepository, countryRepository, occupationRepository);
         
         // Act
-        var act = () => handler.Handle(command, CancellationToken.None);
+        var act = () => sut.Handle(command, CancellationToken.None);
 
         // Assert
         await act.Should().ThrowAsync<BadRequestException>();
     }
     
     [Fact]
-    public async void Should_FailUserCheckWithNonExistingUserIdAsync()
+    public async Task Should_FailUserCheckWithNonExistingUserIdAsync()
     {
         // Arrange
         var mockLogger = new Mock<ILogger<UpdateUser.Handler>>();
         var occupationRepository = new MockOccupationsRepository();
         var countryRepository = new MockCountriesRepository();
         var languageRepository = new LanguageRepository();
-        
-        var command = new UpdateUser.Command(null, null, null, null, null, null, null, "not a code",null,null, null, null, null);
+        var command = new UpdateUserCommandBuilder().Build();
         command.SetAuth(Guid.Empty);
-        var handler = new UpdateUser.Handler(_dbContext, mockLogger.Object, languageRepository, countryRepository, occupationRepository);
+        var sut = new UpdateUser.Handler(_dbContext, mockLogger.Object, languageRepository, countryRepository, occupationRepository);
         
         // Act
-        var act = () => handler.Handle(command, CancellationToken.None);
+        var act = () => sut.Handle(command, CancellationToken.None);
 
         // Assert
         await act.Should().ThrowAsync<InvalidOperationException>();
     }
 
     [Fact]
-    public async void Should_FailUserUpdateWithMaxLengths_FluentValidation()
+    public async Task Should_FailUserUpdateWithMaxLengths_FluentValidation()
     {
         // Arrange
         var validator = new UpdateUser.CommandValidator();
         var dbEntities = await APIUserFactory.CreateAndGetLogInUser(_dbContext);
-        var command = new UpdateUser.Command(new string('*', 256), new string('*', 256), new string('*', 520),null, null, "12345678910", "12345678910", "12345678910", "12345678910", null, null, "superghumangender123", null);
+        var command = new UpdateUserCommandBuilder()
+            .WithFirstName(new string('*', 256))
+            .WithLastName(new string('*', 256))
+            .WithAddress(new string('*', 256))
+            .WithJobsDataConsent(null)
+            .WithImmigrationDataConsent(null)
+            .WithCountryOfBirthCode("12345678910")
+            .WithNativeLanguageCode("12345678910")
+            .WithOccupationCode("12345678910")
+            .WithCitizenshipCode("12345678910")
+            .WithJobTitles(null)
+            .WithRegions(null)
+            .WithGender((Gender)3)
+            .WithDateOfBirth(null)
+            .Build();
         command.SetAuth(dbEntities.user.Id);
 
         // Assert
         var result = validator.TestValidate(command);
+        
         result.ShouldHaveValidationErrorFor(user => user.FirstName);
         result.ShouldHaveValidationErrorFor(user => user.LastName);
         result.ShouldHaveValidationErrorFor(user => user.Address);


### PR DESCRIPTION
Muokattu User data modeleita, jotta saadaan testbedin kautta kulkemaan Users/Profile data product. Get/Update user model palauttaa testbedin vastaavan datan, ja tietokantaan Users tauluun on lisätty kolumneja tukemaan tuota dataa. StreetAddress mäpätään vielä vanhaan Address kenttään jotta ei rikota mitään. Ehkä tuonkin voisi nimetä uudelleen ja migraatio sitten osaa muuttaa datan tietokannassa?

Laitetaan tämä näin alustavana katselmointina, että onko menty ihan metsään, sillä koodissa on vielä pari TODO:ta mitkä pitäisi korjata.