### PR TITLE
added productizer actions to read/update user consents

### DIFF
--- a/Tools/Postman/UsersAPI.postman_collection.json
+++ b/Tools/Postman/UsersAPI.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "b833c2e3-65dd-4dee-8e14-f9fdbda954f9",
+		"_postman_id": "2ae26570-3c6e-436b-8041-c9369c1fadd7",
 		"name": "UsersAPI",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "22874660"
@@ -668,6 +668,58 @@
 						"lassipatanen",
 						"User",
 						"Profile",
+						"Write"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Productizer User Consents Get",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"url": {
+					"raw": "{{host}}/productizer/test/lassipatanen/User/Consents",
+					"host": [
+						"{{host}}"
+					],
+					"path": [
+						"productizer",
+						"test",
+						"lassipatanen",
+						"User",
+						"Consents"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Productizer User Consents Write",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"immigrationDataConsent\": false,\n    \"jobsDataConsent\": true\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{host}}/productizer/test/lassipatanen/User/Consents/Write",
+					"host": [
+						"{{host}}"
+					],
+					"path": [
+						"productizer",
+						"test",
+						"lassipatanen",
+						"User",
+						"Consents",
 						"Write"
 					]
 				}

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/GetConsents.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/GetConsents.cs
@@ -1,0 +1,61 @@
+﻿using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Swashbuckle.AspNetCore.Annotations;
+using VirtualFinland.UserAPI.Data;
+using VirtualFinland.UserAPI.Helpers.Swagger;
+
+namespace VirtualFinland.UserAPI.Activities.Productizer.Operations;
+
+public static class GetConsents
+{
+    [SwaggerSchema(Title = "ConsentsRequest")]
+    public class Query : IRequest<Consents>
+    {
+        [SwaggerIgnore]
+        public Guid? UserId { get; }
+
+        public Query(Guid? userId)
+        {
+            this.UserId = userId;
+        }
+    }
+
+    public class QueryValidator : AbstractValidator<Query>
+    {
+        public QueryValidator()
+        {
+            RuleFor(query => query.UserId).NotNull().NotEmpty();
+        }
+    }
+
+    public class Handler : IRequestHandler<Query, Consents>
+    {
+        private readonly UsersDbContext _usersDbContext;
+        private readonly ILogger<Handler> _logger;
+
+        public Handler(UsersDbContext usersDbContext, ILogger<Handler> logger)
+        {
+            _usersDbContext = usersDbContext;
+            _logger = logger;
+        }
+
+        public async Task<Consents> Handle(Query request, CancellationToken cancellationToken)
+        {
+            var dbUser = await _usersDbContext.Users.SingleAsync(o => o.Id == request.UserId, cancellationToken: cancellationToken);
+            _logger.LogDebug("User consents retrieved for user: {DbUserId}", dbUser.Id);
+
+            return new Consents(
+                dbUser.ImmigrationDataConsent,
+                dbUser.JobsDataConsent
+                );
+        }
+    }
+
+    [SwaggerSchema(Title = "ConsentsResponse")]
+    public record Consents(
+        bool ImmigrationDataConsent,
+        bool JobsDataConsent
+        );
+
+}

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/UpdateConsents.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/UpdateConsents.cs
@@ -1,0 +1,75 @@
+﻿using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Swashbuckle.AspNetCore.Annotations;
+using VirtualFinland.UserAPI.Data;
+using VirtualFinland.UserAPI.Helpers.Swagger;
+
+namespace VirtualFinland.UserAPI.Activities.Productizer.Operations;
+
+public static class UpdateConsents
+{
+    [SwaggerSchema(Title = "UpdateConsentsRequest")]
+    public class Command : IRequest<Consents>
+    {
+        public bool? JobsDataConsent { get; set; }
+
+        public bool? ImmigrationDataConsent { get; set; }
+
+        [SwaggerIgnore]
+        public Guid? UserId { get; private set; }
+
+
+        public Command(bool? jobsDataConsent, bool? immigrationDataConsent)
+        {
+            this.JobsDataConsent = jobsDataConsent;
+            this.ImmigrationDataConsent = immigrationDataConsent;
+        }
+
+        public void SetAuth(Guid? userDbId)
+        {
+            this.UserId = userDbId;
+        }
+    }
+
+    public class CommandValidator : AbstractValidator<Command>
+    {
+        public CommandValidator()
+        {
+            RuleFor(command => command.UserId).NotNull().NotEmpty();
+        }
+    }
+
+    public class Handler : IRequestHandler<Command, Consents>
+    {
+        private readonly UsersDbContext _usersDbContext;
+        private readonly ILogger<Handler> _logger;
+
+        public Handler(UsersDbContext usersDbContext, ILogger<Handler> logger)
+        {
+            _usersDbContext = usersDbContext;
+            _logger = logger;
+        }
+
+        public async Task<Consents> Handle(Command request, CancellationToken cancellationToken)
+        {
+            var dbUser = await _usersDbContext.Users.SingleAsync(o => o.Id == request.UserId, cancellationToken: cancellationToken);
+
+            dbUser.Modified = DateTime.UtcNow;
+            dbUser.ImmigrationDataConsent = request.ImmigrationDataConsent ?? dbUser.ImmigrationDataConsent;
+            dbUser.JobsDataConsent = request.JobsDataConsent ?? dbUser.JobsDataConsent;
+
+            await _usersDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogDebug("User data updated for user: {DbUserId}", dbUser.Id);
+
+            return new Consents(
+                dbUser.ImmigrationDataConsent,
+                dbUser.JobsDataConsent);
+        }
+    }
+    [SwaggerSchema(Title = "UpdateConsentsResponse")]
+    public record Consents(
+        bool ImmigrationDataConsent,
+        bool JobsDataConsent);
+}

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/ProductizerController.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/ProductizerController.cs
@@ -43,4 +43,24 @@ public class ProductizerController : ControllerBase
         return Ok(await _mediator.Send(command));
     }
 
+    [HttpPost("/productizer/test/lassipatanen/User/Consents")]
+    [SwaggerOperation(Summary = "Get the current logged user personal consents (Testbed Productizer)", Description = "Returns the current logged user own personal consents.")]
+    [ProducesResponseType(typeof(GetConsents.Consents), StatusCodes.Status200OK)]
+    [ProducesErrorResponseType(typeof(ProblemDetails))]
+    public async Task<IActionResult> GetUserConsents()
+    {
+        await _authGwVerificationService.AuthGwVerification(this.Request);
+        return Ok(await _mediator.Send(new GetConsents.Query(await _authGwVerificationService.GetCurrentUserId(this.Request))));
+    }
+
+    [HttpPost("/productizer/test/lassipatanen/User/Consents/Write")]
+    [SwaggerOperation(Summary = "Updates the current logged user personal consents (Testbed Productizer)", Description = "Updates the current logged user own personal consents.")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesErrorResponseType(typeof(ProblemDetails))]
+    public async Task<IActionResult> UpdateUserConsents(UpdateConsents.Command command)
+    {
+        await _authGwVerificationService.AuthGwVerification(this.Request);
+        command.SetAuth(await _authGwVerificationService.GetCurrentUserId(this.Request));
+        return Ok(await _mediator.Send(command));
+    }
 }


### PR DESCRIPTION
Tätä ei mahdollisesti tarvita ollenkaan, koska consenttien handlaus pitäis tehdä varmaan joka tapauksessa eri tavalla. Mutta jos välttämättä halutaan saada jotain profiilidataan liittyvää Write -toiminallisuutta kulkemaan productizerin läpi, niin ainut action tähän liittyen on tällä hetkellä rekisteröintisovelluksessa, missä käyttäjä voi antaan consenttinsa/revokkaa consentin profiilidatan käytölle.