### PR TITLE
fix: docker starter script fixes for non-arm64 archs

### DIFF
--- a/Tools/Scripts/startApiInDocker.sh
+++ b/Tools/Scripts/startApiInDocker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e # exit on error
 echo "Starting Users API in docker"
 cd ./VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI
 echo "Work Directory:"
@@ -10,6 +10,6 @@ echo "Starting LocalDev in Docker"
 cd ../../../
 echo "Work Directory:"
 pwd
-docker-compose -f ./Tools/Docker/docker-compose-localdev.yml up
-docker-compose -f ./Tools/Docker/docker-compose-localdev.yml down
+docker compose -f ./Tools/Docker/docker-compose-localdev.yml up
+docker compose -f ./Tools/Docker/docker-compose-localdev.yml down
 

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Dockerfile
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Dockerfile
@@ -4,15 +4,13 @@ EXPOSE 80
 EXPOSE 443
 
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
-ARG runtimeType=linux-arm64
-ARG cpuArch
 WORKDIR /src
 COPY . .
 RUN dotnet restore "VirtualFinland.UsersAPI.csproj"
 COPY . .
 RUN dotnet build "VirtualFinland.UsersAPI.csproj" -c Release -o /app/build
 FROM build AS publish
-RUN dotnet publish "VirtualFinland.UsersAPI.csproj" -c Release -o /app/publish
+RUN dotnet publish "VirtualFinland.UsersAPI.csproj" -p:PublishReadyToRun=True -c Release -o /app/publish --self-contained -r linux-x64 
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .


### PR DESCRIPTION
- fix errs in docker runner script started runtime of local dev
- note: use the docker provided compose command instead of the `docker-compose` script