### PR TITLE
Testbed consent API and local development tools upgrade

### DIFF
--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/ProductizerController.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/ProductizerController.cs
@@ -2,7 +2,6 @@ using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using VirtualFinland.UserAPI.Activities.Productizer.Operations;
-using VirtualFinland.UserAPI.Helpers;
 using VirtualFinland.UserAPI.Helpers.Services;
 
 namespace VirtualFinland.UserAPI.Activities.Productizer;
@@ -20,25 +19,25 @@ public class ProductizerController : ControllerBase
         _mediator = mediator;
         _authGwVerificationService = authGwVerificationService;
     }
-    
+
     [HttpPost("/productizer/test/lassipatanen/User/Profile")]
     [SwaggerOperation(Summary = "Get the current logged user personal profile (Testbed Productizer)", Description = "Returns the current logged user own personal details and his default search profile.")]
-    [ProducesResponseType(typeof(GetUser.User),StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(GetUser.User), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesErrorResponseType(typeof(ProblemDetails))]
     public async Task<IActionResult> GetTestbedIdentityUser()
     {
-        await _authGwVerificationService.AuthGwVerification(this.Request);
+        await _authGwVerificationService.AuthGwVerification(this.Request, true);
         return Ok(await _mediator.Send(new GetUser.Query(await _authGwVerificationService.GetCurrentUserId(this.Request))));
     }
-    
+
     [HttpPost("/productizer/test/lassipatanen/User/Profile/Write")]
     [SwaggerOperation(Summary = "Updates the current logged user personal profile (Testbed Productizer)", Description = "Updates the current logged user own personal details and his default search profile.")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesErrorResponseType(typeof(ProblemDetails))]
     public async Task<IActionResult> UpdateUser(UpdateUser.Command command)
     {
-        await _authGwVerificationService.AuthGwVerification(this.Request);
+        await _authGwVerificationService.AuthGwVerification(this.Request, true);
         command.SetAuth(await _authGwVerificationService.GetCurrentUserId(this.Request));
         return Ok(await _mediator.Send(command));
     }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/GetConsents.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/GetConsents.cs
@@ -7,6 +7,9 @@ using VirtualFinland.UserAPI.Helpers.Swagger;
 
 namespace VirtualFinland.UserAPI.Activities.User.Operations;
 
+/**
+* @OBSOLETE
+*/
 public static class GetConsents
 {
     [SwaggerSchema(Title = "ConsentsRequest")]
@@ -20,7 +23,7 @@ public static class GetConsents
             this.UserId = userId;
         }
     }
-    
+
     public class QueryValidator : AbstractValidator<Query>
     {
         public QueryValidator()
@@ -44,18 +47,18 @@ public static class GetConsents
         {
             var dbUser = await _usersDbContext.Users.SingleAsync(o => o.Id == request.UserId, cancellationToken: cancellationToken);
             _logger.LogDebug("User consents retrieved for user: {DbUserId}", dbUser.Id);
-            
+
             return new Consents(
                 dbUser.ImmigrationDataConsent,
                 dbUser.JobsDataConsent
                 );
         }
     }
-    
+
     [SwaggerSchema(Title = "ConsentsResponse")]
     public record Consents(
         bool ImmigrationDataConsent,
         bool JobsDataConsent
         );
-    
+
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/UpdateConsents.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/UpdateConsents.cs
@@ -7,13 +7,16 @@ using VirtualFinland.UserAPI.Helpers.Swagger;
 
 namespace VirtualFinland.UserAPI.Activities.User.Operations;
 
+/**
+* @OBSOLETE
+*/
 public static class UpdateConsents
 {
     [SwaggerSchema(Title = "UpdateConsentsRequest")]
     public class Command : IRequest<Consents>
     {
         public bool? JobsDataConsent { get; set; }
-        
+
         public bool? ImmigrationDataConsent { get; set; }
 
         [SwaggerIgnore]
@@ -41,33 +44,33 @@ public static class UpdateConsents
     }
 
     public class Handler : IRequestHandler<Command, Consents>
+    {
+        private readonly UsersDbContext _usersDbContext;
+        private readonly ILogger<Handler> _logger;
+
+        public Handler(UsersDbContext usersDbContext, ILogger<Handler> logger)
         {
-            private readonly UsersDbContext _usersDbContext;
-            private readonly ILogger<Handler> _logger;
-
-            public Handler(UsersDbContext usersDbContext, ILogger<Handler> logger)
-            {
-                _usersDbContext = usersDbContext;
-                _logger = logger;
-            }
-
-            public async Task<Consents> Handle(Command request, CancellationToken cancellationToken)
-            {
-                var dbUser = await _usersDbContext.Users.SingleAsync(o => o.Id == request.UserId, cancellationToken: cancellationToken);
-                
-                dbUser.Modified = DateTime.UtcNow;
-                dbUser.ImmigrationDataConsent = request.ImmigrationDataConsent ?? dbUser.ImmigrationDataConsent;
-                dbUser.JobsDataConsent = request.JobsDataConsent ?? dbUser.JobsDataConsent;
-                
-                await _usersDbContext.SaveChangesAsync(cancellationToken);
-                
-                _logger.LogDebug("User data updated for user: {DbUserId}", dbUser.Id);
-
-                return new Consents(
-                    dbUser.ImmigrationDataConsent,
-                    dbUser.JobsDataConsent);
-            }
+            _usersDbContext = usersDbContext;
+            _logger = logger;
         }
+
+        public async Task<Consents> Handle(Command request, CancellationToken cancellationToken)
+        {
+            var dbUser = await _usersDbContext.Users.SingleAsync(o => o.Id == request.UserId, cancellationToken: cancellationToken);
+
+            dbUser.Modified = DateTime.UtcNow;
+            dbUser.ImmigrationDataConsent = request.ImmigrationDataConsent ?? dbUser.ImmigrationDataConsent;
+            dbUser.JobsDataConsent = request.JobsDataConsent ?? dbUser.JobsDataConsent;
+
+            await _usersDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogDebug("User data updated for user: {DbUserId}", dbUser.Id);
+
+            return new Consents(
+                dbUser.ImmigrationDataConsent,
+                dbUser.JobsDataConsent);
+        }
+    }
     [SwaggerSchema(Title = "UpdateConsentsResponse")]
     public record Consents(
         bool ImmigrationDataConsent,

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Constants.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Constants.cs
@@ -37,7 +37,7 @@ public static class Constants
                 return "DefaultTestBedBearerScheme";
             }
         }
-        
+
         public static string SuomiFiBearerScheme
         {
             get
@@ -45,7 +45,7 @@ public static class Constants
                 return "SuomiFiBearerScheme";
             }
         }
-        
+
         public static string SinunaScheme
         {
             get
@@ -72,12 +72,20 @@ public static class Constants
                 return "x-authorization-context";
             }
         }
-        
+
         public static string XAuthorizationProvider
         {
             get
             {
                 return "x-authorization-provider";
+            }
+        }
+
+        public static string XConsentToken
+        {
+            get
+            {
+                return "x-consent-token";
             }
         }
     }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/UsersDatabase/User.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/UsersDatabase/User.cs
@@ -24,8 +24,8 @@ public class User : IEntity
     [MaxLength(512)]
     public string? Country { get; set; }
 
-    public bool ImmigrationDataConsent { get; set; }
-    public bool JobsDataConsent { get; set; }
+    public bool ImmigrationDataConsent { get; set; } // @OBSOLETE
+    public bool JobsDataConsent { get; set; } // @OBSOLETE
     public DateOnly? DateOfBirth { get; set; }
     public Gender Gender { get; set; }
 

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.json
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.json
@@ -16,9 +16,9 @@
     "OpenIDConfigurationURL": "https://login.iam.qa.sinuna.fi/oxauth/.well-known/openid-configuration"
   },
   "AuthGW": {
-    "JwksJsonURL": "https://q88uo5prmh.execute-api.eu-north-1.amazonaws.com/auth/saml2/suomifi/.well-known/jwks.json",
+    "JwksJsonURL": "https://virtualfinland-authgw.localhost/auth/saml2/suomifi/.well-known/jwks.json",
     "Issuer": "virtual-finland/authentication-gw/suomifi",
-    "AuthorizeURL": "https://q88uo5prmh.execute-api.eu-north-1.amazonaws.com/authorize"
+    "AuthorizeURL": "https://virtualfinland-authgw.localhost/authorize"
   },
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Database=postgres;Username=postgres;Password=example"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3.1"
+
+services:
+  usersapi:
+    container_name: usersApi
+    image: virtualfinland/usersapi:latest
+    build:
+      context: ./VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI
+      dockerfile: Dockerfile
+    ports:
+      - 5001:80
+    depends_on:
+      postgresdb:
+        condition: service_healthy
+    environment:
+      ASPNETCORE_ENVIRONMENT: dev
+      CONNECTIONSTRINGS__DEFAULTCONNECTION: Host=postgresdb;Database=postgres;Username=postgres;Password=example
+      AWS_REGION: eu-north-1
+
+  postgresdb:
+    container_name: postgresdb
+    image: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_PASSWORD: example
+
+  adminer:
+    image: adminer
+    ports:
+      - 8080:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: virtualfinland/usersapi:latest
     build:
       context: ./VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI
-      dockerfile: Dockerfile
+      dockerfile: ${USERAPI_DOCKERFILE:-Dockerfile}
     ports:
       - 5001:80
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3.1"
 
 services:
   usersapi:
-    container_name: usersApi
     image: virtualfinland/usersapi:latest
     build:
       context: ./VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI
@@ -18,7 +17,6 @@ services:
       AWS_REGION: eu-north-1
 
   postgresdb:
-    container_name: postgresdb
     image: postgres
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
@@ -29,8 +27,13 @@ services:
       - 5432:5432
     environment:
       POSTGRES_PASSWORD: example
+    volumes:
+      - postgresdb:/var/lib/postgresql/data
 
   adminer:
     image: adminer
     ports:
       - 8080:8080
+
+volumes:
+  postgresdb:


### PR DESCRIPTION
- user profile data productizer endpoints now require a `x-consent-token` header
    - the token is verified with the authgw `/authorize`-endpoint: now has an optional feat for that. 
- add a `docker-compose.yml` -file to the root of project for local development tools