### PR TITLE
productizers respond with empty body when bad authorization

### DIFF
--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/ProductizerController.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/ProductizerController.cs
@@ -1,4 +1,3 @@
-using System.Security.Claims;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
@@ -7,7 +6,6 @@ using VirtualFinland.UserAPI.Activities.Productizer.Operations;
 using VirtualFinland.UserAPI.Activities.Productizer.Operations.BasicInformation;
 using VirtualFinland.UserAPI.Activities.Productizer.Operations.JobApplicantProfile;
 using VirtualFinland.UserAPI.Exceptions;
-using VirtualFinland.UserAPI.Helpers;
 using VirtualFinland.UserAPI.Helpers.Services;
 
 namespace VirtualFinland.UserAPI.Activities.Productizer;
@@ -143,11 +141,9 @@ public class ProductizerController : ControllerBase
             _logger.LogInformation("Could not get userId for user with error message: {Error}. Try create new user", e.Message);
             try
             {
-                var claimsUserId =
-                    User.FindFirst(ClaimTypes.NameIdentifier)?.Value ??
-                    User.FindFirst(Constants.Web.ClaimUserId)?.Value;
-                var claimsIssuer = User.Claims.First().Issuer;
-                var query = new VerifyIdentityUser.Query(claimsUserId, claimsIssuer);
+                // Token should be verified before this point
+                var jwkToken = _authenticationService.ParseAuthenticationHeader(Request);
+                var query = new VerifyIdentityUser.Query(jwkToken.UserId, jwkToken.Issuer);
                 var createdUser = await _mediator.Send(query);
                 userId = createdUser.Id;
                 _logger.LogInformation("New user was created with Id: {UserId}", userId);

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/ProductizerController.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/ProductizerController.cs
@@ -129,6 +129,10 @@ public class ProductizerController : ControllerBase
         return Ok(await _mediator.Send(command));
     }
 
+    /// <summary>
+    ///     If user is not found in database, create new user and return users Id
+    ///     - authentication header / token should be verified before calling this method
+    /// </summary>
     private async Task<Guid?> GetUserIdOrCreateNewUserWithId()
     {
         Guid? userId;
@@ -141,7 +145,6 @@ public class ProductizerController : ControllerBase
             _logger.LogInformation("Could not get userId for user with error message: {Error}. Try create new user", e.Message);
             try
             {
-                // Token should be verified before this point
                 var jwkToken = _authenticationService.ParseAuthenticationHeader(Request);
                 var query = new VerifyIdentityUser.Query(jwkToken.UserId, jwkToken.Issuer);
                 var createdUser = await _mediator.Send(query);

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/ProductizerController.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/ProductizerController.cs
@@ -1,6 +1,5 @@
 using System.Security.Claims;
 using MediatR;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using VirtualFinland.UserAPI.Activities.Identity.Operations;
@@ -14,7 +13,6 @@ using VirtualFinland.UserAPI.Helpers.Services;
 namespace VirtualFinland.UserAPI.Activities.Productizer;
 
 [ApiController]
-[Authorize]
 [ProducesResponseType(StatusCodes.Status401Unauthorized)]
 [Produces("application/json")]
 public class ProductizerController : ControllerBase

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Services/AuthGwVerificationService.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Services/AuthGwVerificationService.cs
@@ -29,6 +29,8 @@ public class AuthGwVerificationService
         try
         {
             var token = request.Headers.Authorization.ToString().Replace("Bearer ", string.Empty);
+            if (string.IsNullOrEmpty(token))
+                throw new NotAuthorizedException("Token is missing");
 
             var httpClient = _httpClientFactory.CreateClient();
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(token);

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Services/AuthenticationService.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Services/AuthenticationService.cs
@@ -15,4 +15,10 @@ public class AuthenticationService
         var person = await _userSecurityService.VerifyAndGetAuthenticatedUser(token);
         return person.Id;
     }
+
+    public UserSecurityService.JWTTokenResult ParseAuthenticationHeader(HttpRequest httpRequest)
+    {
+        var token = httpRequest.Headers.Authorization.ToString().Replace("Bearer ", string.Empty);
+        return _userSecurityService.ParseJWTToken(token);
+    }
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Services/UserSecurityService.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Services/UserSecurityService.cs
@@ -16,7 +16,7 @@ public class UserSecurityService
         _usersDbContext = usersDbContext;
         _logger = logger;
     }
-    
+
     /// <summary>
     /// This function tries to verify that the given token has a valid created user account in the user DB. If not the client should "verify" the token through the IdentityController
     /// </summary>
@@ -25,19 +25,38 @@ public class UserSecurityService
     /// <exception cref="NotAuthorizedException">If user id and the issuer are not found in the DB for any given user, this is not a valid user within the users database.</exception>
     public async Task<Person> VerifyAndGetAuthenticatedUser(string token)
     {
-        var issuer = GetTokenIssuer(token);
-        var userId = GetTokenUserId(token);
-        
+        var jwtTokenResult = ParseJWTToken(token);
+
         try
         {
-            var externalIdentity = await _usersDbContext.ExternalIdentities.SingleAsync(o => o.IdentityId == userId && o.Issuer == issuer, CancellationToken.None);
+            var externalIdentity = await _usersDbContext.ExternalIdentities.SingleAsync(o => o.IdentityId == jwtTokenResult.UserId && o.Issuer == jwtTokenResult.Issuer, CancellationToken.None);
             return await _usersDbContext.Persons.SingleAsync(o => o.Id == externalIdentity.UserId, CancellationToken.None);
         }
         catch (InvalidOperationException e)
         {
-            _logger.LogWarning("User could not be identified as a valid user: {RequestClaimsUserId} from issuer: {RequestClaimsIssuer}", userId, issuer);
+            _logger.LogWarning("User could not be identified as a valid user: {RequestClaimsUserId} from issuer: {RequestClaimsIssuer}", jwtTokenResult.UserId, jwtTokenResult.Issuer);
             throw new NotAuthorizedException("User could not be identified as a valid user. Use the verify path to make sure that the given access token is valid in the system: /identity/testbed/verify", e);
         }
+    }
+
+    /// <summary>
+    /// Parses the JWT token and returns the issuer and the user id
+    /// </summary>
+    public JWTTokenResult ParseJWTToken(string token)
+    {
+        if (string.IsNullOrEmpty(token))
+        {
+            throw new NotAuthorizedException("No token provided");
+        }
+
+        var issuer = GetTokenIssuer(token);
+        var userId = GetTokenUserId(token);
+
+        if (userId == null || issuer == null)
+        {
+            throw new NotAuthorizedException("The given token is not valid");
+        }
+        return new JWTTokenResult() { UserId = userId, Issuer = issuer };
     }
 
     private static string? GetTokenUserId(string token)
@@ -58,5 +77,11 @@ public class UserSecurityService
         var tokenHandler = new JwtSecurityTokenHandler();
         var canReadToken = tokenHandler.CanReadToken(token);
         return canReadToken ? tokenHandler.ReadJwtToken(token).Issuer : string.Empty;
+    }
+
+    public class JWTTokenResult
+    {
+        public string? UserId { get; set; }
+        public string? Issuer { get; set; }
     }
 }


### PR DESCRIPTION
**problem:**
- aspnet core defaults to empty http responses when dealing with errors
- the testbed product gateway needs a body / payload when handling the data source error codes / exceptions
- so when relying on the aspnet core error handlers, the emitted errors are being blocked by the testbed gw leaving the client clueless
- scope of problem is the authentication / authorization exceptions

**fix:**
- on productizers controller, disable the aspnet core authorizer:
    - the token verification is already done at the controller method level (`_authGwVerificationService.VerifyTokens()`)
    - errors handled by the error handling middleware -> good errors
    - stops the token being verified twice (by the aspnet and then again at controller level), one time should be enough.

**alternative fix:**
- maybe it would be possible to alter/configure the aspnet core or maybe the authorization module for custom exception handling?
