### PR TITLE
feat: users profile productizer verify the correct consent

### DIFF
--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/ProductizerController.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/ProductizerController.cs
@@ -19,17 +19,20 @@ public class ProductizerController : ControllerBase
     private readonly AuthGwVerificationService _authGwVerificationService;
     private readonly IMediator _mediator;
     private readonly ILogger<ProductizerController> _logger;
+    private readonly string _userProfileDataSourceURI;
 
     public ProductizerController(
         IMediator mediator,
         AuthGwVerificationService authGwVerificationService,
         AuthenticationService authenticationService,
-        ILogger<ProductizerController> logger)
+        ILogger<ProductizerController> logger,
+        IConfiguration configuration)
     {
         _mediator = mediator;
         _authGwVerificationService = authGwVerificationService;
         _authenticationService = authenticationService;
         _logger = logger;
+        _userProfileDataSourceURI = configuration["ConsentDataSources:UserProfile"];
     }
 
     [HttpPost("/productizer/test/lassipatanen/User/Profile")]
@@ -40,7 +43,7 @@ public class ProductizerController : ControllerBase
     [ProducesErrorResponseType(typeof(ProblemDetails))]
     public async Task<IActionResult> GetTestbedIdentityUser()
     {
-        await _authGwVerificationService.VerifyTokens(Request, true);
+        await _authGwVerificationService.VerifyTokens(Request, _userProfileDataSourceURI);
         return Ok(await _mediator.Send(new GetUser.Query(await _authenticationService.GetCurrentUserId(Request))));
     }
 
@@ -51,7 +54,7 @@ public class ProductizerController : ControllerBase
     [ProducesErrorResponseType(typeof(ProblemDetails))]
     public async Task<IActionResult> UpdateUser(UpdateUser.Command command)
     {
-        await _authGwVerificationService.VerifyTokens(Request, true);
+        await _authGwVerificationService.VerifyTokens(Request, _userProfileDataSourceURI);
         command.SetAuth(await _authenticationService.GetCurrentUserId(Request));
         return Ok(await _mediator.Send(command));
     }
@@ -63,7 +66,7 @@ public class ProductizerController : ControllerBase
     [ProducesErrorResponseType(typeof(ProblemDetails))]
     public async Task<IActionResult> GetPersonBasicInformation()
     {
-        await _authGwVerificationService.VerifyTokens(Request, false);
+        await _authGwVerificationService.VerifyTokens(Request);
 
         Guid? userId;
         try
@@ -88,7 +91,7 @@ public class ProductizerController : ControllerBase
     public async Task<IActionResult> SaveOrUpdatePersonBasicInformation(
         UpdatePersonBasicInformation.Command command)
     {
-        await _authGwVerificationService.VerifyTokens(Request, false);
+        await _authGwVerificationService.VerifyTokens(Request);
         command.SetAuth(await GetUserIdOrCreateNewUserWithId());
         return Ok(await _mediator.Send(command));
     }
@@ -100,7 +103,7 @@ public class ProductizerController : ControllerBase
     [ProducesErrorResponseType(typeof(ProblemDetails))]
     public async Task<IActionResult> GetPersonJobApplicantInformation()
     {
-        await _authGwVerificationService.VerifyTokens(Request, false);
+        await _authGwVerificationService.VerifyTokens(Request);
 
         Guid? userId;
         try
@@ -124,7 +127,7 @@ public class ProductizerController : ControllerBase
     [ProducesErrorResponseType(typeof(ProblemDetails))]
     public async Task<IActionResult> SaveOrUpdatePersonJobApplicantProfile(UpdateJobApplicantProfile.Command command)
     {
-        await _authGwVerificationService.VerifyTokens(Request, false);
+        await _authGwVerificationService.VerifyTokens(Request);
         command.SetAuth(await GetUserIdOrCreateNewUserWithId());
         return Ok(await _mediator.Send(command));
     }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Constants.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Constants.cs
@@ -22,5 +22,7 @@ public static class Constants
         public static string XAuthorizationContext => "x-authorization-context";
         public static string XAuthorizationProvider => "x-authorization-provider";
         public static string XConsentToken => "x-consent-token";
+        public static string XconsentDataSource => "x-consent-data-source";
+        public static string XconsentUserId => "x-consent-user-id";
     }
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/Shared/AuthorizeResponse.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/Shared/AuthorizeResponse.cs
@@ -1,9 +1,14 @@
 
+using System.Text.Json.Serialization;
+
 namespace VirtualFinland.UserAPI.Models.Shared;
 
 public class AuthorizeResponse
 {
+    [JsonPropertyName("message")]
     public string Message { get; set; } = string.Empty;
+    [JsonPropertyName("authorization")]
     public AuthorizeResponseAuthorization Authorization { get; set; } = new AuthorizeResponseAuthorization();
+    [JsonPropertyName("consent")]
     public AuthorizeResponseConsent? Consent { get; set; }
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/Shared/AuthorizeResponse.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/Shared/AuthorizeResponse.cs
@@ -1,0 +1,9 @@
+
+namespace VirtualFinland.UserAPI.Models.Shared;
+
+public class AuthorizeResponse
+{
+    public string Message { get; set; } = string.Empty;
+    public AuthorizeResponseAuthorization Authorization { get; set; } = new AuthorizeResponseAuthorization();
+    public AuthorizeResponseConsent? Consent { get; set; }
+}

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/Shared/AuthorizeResponseAuthorization.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/Shared/AuthorizeResponseAuthorization.cs
@@ -1,0 +1,11 @@
+
+namespace VirtualFinland.UserAPI.Models.Shared;
+
+public class AuthorizeResponseAuthorization
+{
+    public string UserId { get; set; } = string.Empty;
+    public string? Email { get; set; }
+    public int ExpiresAt { get; set; }
+    public int IssuedAt { get; set; }
+    public string Issuer { get; set; } = string.Empty;
+}

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/Shared/AuthorizeResponseAuthorization.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/Shared/AuthorizeResponseAuthorization.cs
@@ -1,11 +1,18 @@
 
+using System.Text.Json.Serialization;
+
 namespace VirtualFinland.UserAPI.Models.Shared;
 
 public class AuthorizeResponseAuthorization
 {
+    [JsonPropertyName("userId")]
     public string UserId { get; set; } = string.Empty;
-    public string? Email { get; set; }
+    [JsonPropertyName("email")]
+    public string Email { get; set; } = string.Empty;
+    [JsonPropertyName("expiresAt")]
     public int ExpiresAt { get; set; }
+    [JsonPropertyName("issuedAt")]
     public int IssuedAt { get; set; }
+    [JsonPropertyName("issuer")]
     public string Issuer { get; set; } = string.Empty;
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/Shared/AuthorizeResponseConsent.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/Shared/AuthorizeResponseConsent.cs
@@ -1,7 +1,19 @@
+using System.Text.Json.Serialization;
 
 namespace VirtualFinland.UserAPI.Models.Shared;
 
 public class AuthorizeResponseConsent
 {
-    public string dataSource { get; set; } = string.Empty;
+    [JsonPropertyName("dataSource")]
+    public string DataSource { get; set; } = string.Empty;
+    [JsonPropertyName("userId")]
+    public string UserId { get; set; } = string.Empty;
+    [JsonPropertyName("email")]
+    public string Email { get; set; } = string.Empty;
+    [JsonPropertyName("expiresAt")]
+    public int ExpiresAt { get; set; }
+    [JsonPropertyName("issuedAt")]
+    public int IssuedAt { get; set; }
+    [JsonPropertyName("issuer")]
+    public string Issuer { get; set; } = string.Empty;
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/Shared/AuthorizeResponseConsent.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/Shared/AuthorizeResponseConsent.cs
@@ -1,0 +1,7 @@
+
+namespace VirtualFinland.UserAPI.Models.Shared;
+
+public class AuthorizeResponseConsent
+{
+    public string dataSource { get; set; } = string.Empty;
+}

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.dev.json
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.dev.json
@@ -9,14 +9,12 @@
     "Domain": "login.testbed.fi",
     "Issuer": "https://login.testbed.fi",
     "Audience": "https://login.testbed.fi",
-    "OpenIDConfigurationURL" : "https://login.testbed.fi/.well-known/openid-configuration"
+    "OpenIDConfigurationURL": "https://login.testbed.fi/.well-known/openid-configuration"
   },
-  "Sinuna" :
-  {
-    "OpenIDConfigurationURL" : "https://login.iam.qa.sinuna.fi/oxauth/.well-known/openid-configuration"
+  "Sinuna": {
+    "OpenIDConfigurationURL": "https://login.iam.qa.sinuna.fi/oxauth/.well-known/openid-configuration"
   },
-  "AuthGW":
-  {
+  "AuthGW": {
     "JwksJsonURL": "https://q88uo5prmh.execute-api.eu-north-1.amazonaws.com/auth/saml2/suomifi/.well-known/jwks.json",
     "Issuer": "virtual-finland/authentication-gw/suomifi",
     "AuthorizeURL": "https://q88uo5prmh.execute-api.eu-north-1.amazonaws.com/authorize"
@@ -29,5 +27,8 @@
     "ISO3166CountriesURL": "https://github.com/mledoze/countries/blob/master/countries.json?raw=true",
     "OccupationsEscoURL": "https://tyomarkkinatori.fi/api/codes/v1/isco",
     "OccupationsFlatURL": "https://tyomarkkinatori.fi/dam/jcr:42efb1fc-93f3-4146-a46f-71c2f9f5eb9b/occupations.json.zip"
+  },
+  "ConsentDataSources": {
+    "UserProfile": "dpp://access_to_finland@testbed.fi/test/lassipatanen/User/Profile"
   }
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.json
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.json
@@ -28,5 +28,8 @@
     "ISO3166CountriesURL": "https://github.com/mledoze/countries/blob/master/countries.json?raw=true",
     "OccupationsEscoURL": "https://tyomarkkinatori.fi/api/codes/v1/isco",
     "OccupationsFlatURL": "https://tyomarkkinatori.fi/dam/jcr:42efb1fc-93f3-4146-a46f-71c2f9f5eb9b/occupations.json.zip"
+  },
+  "ConsentDataSources": {
+    "UserProfile": "dpp://access_to_finland@testbed.fi/test/lassipatanen/User/Profile"
   }
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.staging.json
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.staging.json
@@ -9,14 +9,12 @@
     "Domain": "login.testbed.fi",
     "Issuer": "https://login.testbed.fi",
     "Audience": "https://login.testbed.fi",
-    "OpenIDConfigurationURL" : "https://login.testbed.fi/.well-known/openid-configuration"
+    "OpenIDConfigurationURL": "https://login.testbed.fi/.well-known/openid-configuration"
   },
-  "Sinuna" :
-  {
-    "OpenIDConfigurationURL" : "https://login.iam.qa.sinuna.fi/oxauth/.well-known/openid-configuration"
+  "Sinuna": {
+    "OpenIDConfigurationURL": "https://login.iam.qa.sinuna.fi/oxauth/.well-known/openid-configuration"
   },
-  "AuthGW":
-  {
+  "AuthGW": {
     "JwksJsonURL": "https://a4j7hhtwlb.execute-api.eu-north-1.amazonaws.com/auth/saml2/suomifi/.well-known/jwks.json",
     "Issuer": "virtual-finland/authentication-gw/suomifi",
     "AuthorizeURL": "https://a4j7hhtwlb.execute-api.eu-north-1.amazonaws.com/authorize"
@@ -29,5 +27,8 @@
     "ISO3166CountriesURL": "https://github.com/mledoze/countries/blob/master/countries.json?raw=true",
     "OccupationsEscoURL": "https://tyomarkkinatori.fi/api/codes/v1/isco",
     "OccupationsFlatURL": "https://tyomarkkinatori.fi/dam/jcr:42efb1fc-93f3-4146-a46f-71c2f9f5eb9b/occupations.json.zip"
+  },
+  "ConsentDataSources": {
+    "UserProfile": "dpp://access_to_finland@testbed.fi/test/lassipatanen/User/Profile"
   }
 }


### PR DESCRIPTION
- the consent for `test/lassipatanen/User/Profile` data product is now verified correctly: 
    - the dataSource-reference was not previously verified -> every otherwise valid consent token passed the check.
    - as in previous implementation, the check is made using [autentication-gw](https://github.com/Virtual-Finland-Development/authentication-gw):s /authorize-endpoint.