### PR TITLE
Vfd 232 job applicant profile productizer sovelluksen vastauksesta puuttuu kenttia educations osiossa

### DIFF
--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/JobApplicantProfile/GetJobApplicantProfile.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/JobApplicantProfile/GetJobApplicantProfile.cs
@@ -48,7 +48,8 @@ public static class GetJobApplicantProfile
                     new PersonJobApplicantProfileResponse.Occupation(
                         x.EscoUri,
                         x.EscoCode,
-                        x.WorkMonths ?? 0
+                        x.WorkMonths ?? 0,
+                        x.Employer
                     )).ToList(),
 
                 Educations = person.Educations.Select(x => new PersonJobApplicantProfileResponse.Education
@@ -74,7 +75,8 @@ public static class GetJobApplicantProfile
                 Certifications = person.Certifications.Select(x =>
                     new PersonJobApplicantProfileResponse.Certification(
                         x.Name,
-                        x.Type
+                        x.EscoUri,
+                        x.InstitutionName
                     )).ToList(),
 
                 Permits = (from p in person.Permits where p.TypeCode is not null select p.TypeCode).ToList(),
@@ -103,22 +105,30 @@ public record PersonJobApplicantProfileResponse
     public List<string> Permits { get; set; } = null!;
     public WorkPreferences workPreferences { get; set; } = null!;
 
-    public record Occupation(string? EscoIdentifier, string? EscoCode, int? WorkExperience);
+    public record Occupation(
+        string? EscoIdentifier, 
+        string? EscoCode, 
+        int? WorkExperience,
+        string? Employer
+    );
 
     public record Education
     {
+        public string? EducationName { get; set; }
         public string? EducationLevel { get; set; }
         public string? EducationField { get; set; }
 
         [JsonConverter(typeof(DateOnlyJsonConverter))]
         public DateOnly? GraduationDate { get; set; }
+
+        public string? InstitutionName { get; set; }
     }
 
     public record LanguageSkill(string? EscoIdentifier, string? LanguageCode, string? SkillLevel);
 
     public record OtherSkill(string? EscoIdentifier, string? SkillLevel);
 
-    public record Certification(string? CertificationName, string? QualificationType);
+    public record Certification(string? CertificationName, string? EscoIdentifier, string? InstitutionName);
 
     public record WorkPreferences(
         List<string> PreferredMunicipality,

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/JobApplicantProfile/GetJobApplicantProfile.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/JobApplicantProfile/GetJobApplicantProfile.cs
@@ -54,9 +54,11 @@ public static class GetJobApplicantProfile
 
                 Educations = person.Educations.Select(x => new PersonJobApplicantProfileResponse.Education
                 {
+                    EducationName = x.Name,
                     EducationField = x.EducationFieldCode,
                     EducationLevel = x.EducationLevelCode,
-                    GraduationDate = x.GraduationDate ?? DateOnly.MinValue
+                    GraduationDate = x.GraduationDate ?? DateOnly.MinValue,
+                    InstitutionName = x.InstitutionName
                 }).ToList(),
 
                 LanguageSkills = person.LanguageSkills.Select(x =>
@@ -82,12 +84,12 @@ public static class GetJobApplicantProfile
                 Permits = (from p in person.Permits where p.TypeCode is not null select p.TypeCode).ToList(),
 
                 workPreferences = new PersonJobApplicantProfileResponse.WorkPreferences(
-                    person.WorkPreferences?.PreferredMunicipalityCode?.ToList() ?? new List<string>(),
+                    person.WorkPreferences?.NaceCode,
                     person.WorkPreferences?.PreferredRegionCode?.ToList() ?? new List<string>(),
-                    person.WorkPreferences?.WorkingLanguageEnum?.ToList() ?? new List<string>(),
-                    person.WorkPreferences?.WorkingTimeCode,
+                    person.WorkPreferences?.PreferredMunicipalityCode?.ToList() ?? new List<string>(),
                     person.WorkPreferences?.EmploymentTypeCode,
-                    person.WorkPreferences?.NaceCode
+                    person.WorkPreferences?.WorkingTimeCode,
+                    person.WorkPreferences?.WorkingLanguageEnum?.ToList() ?? new List<string>()
                 )
             };
         }
@@ -106,8 +108,8 @@ public record PersonJobApplicantProfileResponse
     public WorkPreferences workPreferences { get; set; } = null!;
 
     public record Occupation(
-        string? EscoIdentifier, 
-        string? EscoCode, 
+        string? EscoIdentifier,
+        string? EscoCode,
         int? WorkExperience,
         string? Employer
     );
@@ -128,14 +130,14 @@ public record PersonJobApplicantProfileResponse
 
     public record OtherSkill(string? EscoIdentifier, string? SkillLevel);
 
-    public record Certification(string? CertificationName, string? EscoIdentifier, string? InstitutionName);
+    public record Certification(string? CertificationName, List<string>? EscoIdentifier, string? InstitutionName);
 
     public record WorkPreferences(
-        List<string> PreferredMunicipality,
+        string? NaceCode,
         List<string> PreferredRegion,
-        List<string> WorkingLanguage,
-        string? WorkingTime,
+        List<string> PreferredMunicipality,
         string? TypeOfEmployment,
-        string? NaceCode
+        string? WorkingTime,
+        List<string> WorkingLanguage
     );
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/JobApplicantProfile/UpdateJobApplicantProfile.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/JobApplicantProfile/UpdateJobApplicantProfile.cs
@@ -103,7 +103,8 @@ public static class UpdateJobApplicantProfile
             person.Certifications = command.Certifications.Select(x => new Certification
             {
                 Name = x.CertificationName,
-                Type = x.QualificationType
+                EscoUri = x.EscoIdentifier,
+                InstitutionName = x.InstitutionName
             }).ToList();
 
             person.WorkPreferences ??= new WorkPreferences();
@@ -148,13 +149,16 @@ public static class UpdateJobApplicantProfile
                 {
                     EscoIdentifier = x.EscoUri,
                     EscoCode = x.EscoCode,
-                    WorkExperience = x.WorkMonths
+                    WorkExperience = x.WorkMonths,
+                    Employer = x.Employer
                 }).ToList(),
                 Educations = person.Educations.Select(x => new Request.Education
                 {
+                    EducationName = x.Name,
                     EducationField = x.EducationFieldCode,
                     EducationLevel = x.EducationLevelCode,
-                    GraduationDate = x.GraduationDate
+                    GraduationDate = x.GraduationDate,
+                    InstitutionName = x.InstitutionName
                 }).ToList(),
                 LanguageSkills = person.LanguageSkills.Select(x => new Request.LanguageSkill
                 {
@@ -169,8 +173,9 @@ public static class UpdateJobApplicantProfile
                 }).ToList(),
                 Certifications = person.Certifications.Select(x => new Request.Certification
                 {
-                    QualificationType = x.Type,
-                    CertificationName = x.Name
+                    CertificationName = x.Name,
+                    EscoIdentifier = x.EscoUri,
+                    InstitutionName = x.InstitutionName
                 }).ToList(),
                 Permits = (from p in person.Permits where p.TypeCode is not null select p.TypeCode).ToList(),
                 WorkPreferences = new Request.WorkPreferenceValues
@@ -207,15 +212,19 @@ public static class UpdateJobApplicantProfile
             public string? EscoIdentifier { get; init; }
             public string? EscoCode { get; init; }
             public int? WorkExperience { get; init; }
+            public string? Employer { get; set; }
         }
 
         public record Education
         {
+            public string? EducationName { get; init; }
             public string? EducationLevel { get; init; }
             public string? EducationField { get; init; }
 
             [JsonConverter(typeof(DateOnlyJsonConverter))]
             public DateOnly? GraduationDate { get; init; }
+            
+            public string? InstitutionName { get; set; }
         }
 
         public record LanguageSkill
@@ -234,7 +243,8 @@ public static class UpdateJobApplicantProfile
         public record Certification
         {
             public string? CertificationName { get; init; }
-            public string? QualificationType { get; init; }
+            public string? EscoIdentifier { get; init; }
+            public string? InstitutionName { get; init; }
         }
 
         public record WorkPreferenceValues

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/JobApplicantProfile/UpdateJobApplicantProfile.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/JobApplicantProfile/UpdateJobApplicantProfile.cs
@@ -77,14 +77,17 @@ public static class UpdateJobApplicantProfile
             {
                 EscoUri = x.EscoIdentifier,
                 EscoCode = x.EscoCode,
-                WorkMonths = x.WorkExperience
+                WorkMonths = x.WorkExperience,
+                Employer = x.Employer
             }).ToList();
 
             person.Educations = command.Educations.Select(x => new Education
             {
+                Name = x.EducationName,
                 EducationLevelCode = x.EducationLevel,
                 EducationFieldCode = x.EducationField,
-                GraduationDate = x.GraduationDate
+                GraduationDate = x.GraduationDate,
+                InstitutionName = x.InstitutionName
             }).ToList();
 
             person.LanguageSkills = command.LanguageSkills.Select(x => new Language
@@ -243,18 +246,18 @@ public static class UpdateJobApplicantProfile
         public record Certification
         {
             public string? CertificationName { get; init; }
-            public string? EscoIdentifier { get; init; }
+            public List<string>? EscoIdentifier { get; init; }
             public string? InstitutionName { get; init; }
         }
 
         public record WorkPreferenceValues
         {
+            public string? NaceCode { get; init; }
             public List<string> PreferredRegion { get; init; } = null!;
             public List<string> PreferredMunicipality { get; init; } = null!;
             public string? TypeOfEmployment { get; init; }
             public string? WorkingTime { get; init; }
             public List<string> WorkingLanguage { get; init; } = null!;
-            public string? NaceCode { get; init; }
         }
     }
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Data/Configuration/CertificationConfiguration.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Data/Configuration/CertificationConfiguration.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VirtualFinland.UserAPI.Models.UsersDatabase;
+
+namespace VirtualFinland.UserAPI.Data.Configuration;
+
+public class CertificationConfiguration : IEntityTypeConfiguration<Certification>
+{
+    public void Configure(EntityTypeBuilder<Certification> entity)
+    {
+        entity.Property(c => c.EscoUri).HasConversion(
+            v => string.Join(',', v),
+            v => v.Split(',', StringSplitOptions.RemoveEmptyEntries).ToList()
+        );
+    }
+}

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Data/UsersDBContext.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Data/UsersDBContext.cs
@@ -42,6 +42,7 @@ public class UsersDbContext : DbContext
         modelBuilder.ApplyConfiguration(new AddressConfiguration());
         modelBuilder.ApplyConfiguration(new PersonAdditionalInformationConfiguration());
         modelBuilder.ApplyConfiguration(new WorkPreferencesConfiguration());
+        modelBuilder.ApplyConfiguration(new CertificationConfiguration());
 
         if (_isTesting) modelBuilder.ApplyConfiguration(new SearchProfileConfiguration());
 

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20230401063938_UpdateCertificationTypeToEscoUri.Designer.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20230401063938_UpdateCertificationTypeToEscoUri.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using VirtualFinland.UserAPI.Data;
@@ -12,9 +13,10 @@ using VirtualFinland.UserAPI.Data;
 namespace VirtualFinland.UserAPI.Migrations
 {
     [DbContext(typeof(UsersDbContext))]
-    partial class UsersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230401063938_UpdateCertificationTypeToEscoUri")]
+    partial class UpdateCertificationTypeToEscoUri
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20230401063938_UpdateCertificationTypeToEscoUri.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20230401063938_UpdateCertificationTypeToEscoUri.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VirtualFinland.UserAPI.Migrations
+{
+    public partial class UpdateCertificationTypeToEscoUri : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "ExternalIdentities",
+                keyColumn: "Id",
+                keyValue: new Guid("e870bcad-b6f2-4dfa-b7c8-c5c9595b7a26"));
+
+            migrationBuilder.DropColumn(
+                name: "Type",
+                table: "Certifications");
+
+            migrationBuilder.AddColumn<string>(
+                name: "EscoUri",
+                table: "Certifications",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.InsertData(
+                table: "ExternalIdentities",
+                columns: new[] { "Id", "Created", "IdentityId", "Issuer", "Modified", "UserId" },
+                values: new object[] { new Guid("5fecb1a4-0682-4246-95c1-7b3192f28692"), new DateTime(2023, 4, 1, 6, 39, 38, 67, DateTimeKind.Utc).AddTicks(3220), "0aa52102-b7d8-4abc-86d2-39bcd3916cf7", "2c0c4e0e-fc7f-4545-a10e-7710d8f95ba0", new DateTime(2023, 4, 1, 6, 39, 38, 67, DateTimeKind.Utc).AddTicks(3220), new Guid("5a8af4b4-8cb4-44ac-8291-010614601719") });
+
+            migrationBuilder.UpdateData(
+                table: "Persons",
+                keyColumn: "Id",
+                keyValue: new Guid("5a8af4b4-8cb4-44ac-8291-010614601719"),
+                columns: new[] { "Created", "Modified" },
+                values: new object[] { new DateTime(2023, 4, 1, 6, 39, 38, 67, DateTimeKind.Utc).AddTicks(3090), new DateTime(2023, 4, 1, 6, 39, 38, 67, DateTimeKind.Utc).AddTicks(3090) });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "ExternalIdentities",
+                keyColumn: "Id",
+                keyValue: new Guid("5fecb1a4-0682-4246-95c1-7b3192f28692"));
+
+            migrationBuilder.DropColumn(
+                name: "EscoUri",
+                table: "Certifications");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Type",
+                table: "Certifications",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.InsertData(
+                table: "ExternalIdentities",
+                columns: new[] { "Id", "Created", "IdentityId", "Issuer", "Modified", "UserId" },
+                values: new object[] { new Guid("e870bcad-b6f2-4dfa-b7c8-c5c9595b7a26"), new DateTime(2023, 2, 14, 12, 24, 50, 429, DateTimeKind.Utc).AddTicks(7405), "f3316a85-a400-4c39-ab42-66afaa1d67be", "e667371b-0499-4e3b-82e8-d5d6959c68b7", new DateTime(2023, 2, 14, 12, 24, 50, 429, DateTimeKind.Utc).AddTicks(7405), new Guid("5a8af4b4-8cb4-44ac-8291-010614601719") });
+
+            migrationBuilder.UpdateData(
+                table: "Persons",
+                keyColumn: "Id",
+                keyValue: new Guid("5a8af4b4-8cb4-44ac-8291-010614601719"),
+                columns: new[] { "Created", "Modified" },
+                values: new object[] { new DateTime(2023, 2, 14, 12, 24, 50, 429, DateTimeKind.Utc).AddTicks(7323), new DateTime(2023, 2, 14, 12, 24, 50, 429, DateTimeKind.Utc).AddTicks(7323) });
+        }
+    }
+}

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20230402061613_CertificationEscoUriToList.Designer.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20230402061613_CertificationEscoUriToList.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using VirtualFinland.UserAPI.Data;
@@ -12,9 +13,10 @@ using VirtualFinland.UserAPI.Data;
 namespace VirtualFinland.UserAPI.Migrations
 {
     [DbContext(typeof(UsersDbContext))]
-    partial class UsersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230402061613_CertificationEscoUriToList")]
+    partial class CertificationEscoUriToList
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20230402061613_CertificationEscoUriToList.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20230402061613_CertificationEscoUriToList.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VirtualFinland.UserAPI.Migrations
+{
+    public partial class CertificationEscoUriToList : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "ExternalIdentities",
+                keyColumn: "Id",
+                keyValue: new Guid("5fecb1a4-0682-4246-95c1-7b3192f28692"));
+
+            migrationBuilder.InsertData(
+                table: "ExternalIdentities",
+                columns: new[] { "Id", "Created", "IdentityId", "Issuer", "Modified", "UserId" },
+                values: new object[] { new Guid("5346f52e-9927-436a-b515-f566c226b853"), new DateTime(2023, 4, 2, 6, 16, 13, 703, DateTimeKind.Utc).AddTicks(5580), "31098ce8-537e-4da3-b18d-3a4e0a34e900", "95b22fff-872b-4929-87e8-4db8509b61f3", new DateTime(2023, 4, 2, 6, 16, 13, 703, DateTimeKind.Utc).AddTicks(5580), new Guid("5a8af4b4-8cb4-44ac-8291-010614601719") });
+
+            migrationBuilder.UpdateData(
+                table: "Persons",
+                keyColumn: "Id",
+                keyValue: new Guid("5a8af4b4-8cb4-44ac-8291-010614601719"),
+                columns: new[] { "Created", "Modified" },
+                values: new object[] { new DateTime(2023, 4, 2, 6, 16, 13, 703, DateTimeKind.Utc).AddTicks(5470), new DateTime(2023, 4, 2, 6, 16, 13, 703, DateTimeKind.Utc).AddTicks(5470) });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "ExternalIdentities",
+                keyColumn: "Id",
+                keyValue: new Guid("5346f52e-9927-436a-b515-f566c226b853"));
+
+            migrationBuilder.InsertData(
+                table: "ExternalIdentities",
+                columns: new[] { "Id", "Created", "IdentityId", "Issuer", "Modified", "UserId" },
+                values: new object[] { new Guid("5fecb1a4-0682-4246-95c1-7b3192f28692"), new DateTime(2023, 4, 1, 6, 39, 38, 67, DateTimeKind.Utc).AddTicks(3220), "0aa52102-b7d8-4abc-86d2-39bcd3916cf7", "2c0c4e0e-fc7f-4545-a10e-7710d8f95ba0", new DateTime(2023, 4, 1, 6, 39, 38, 67, DateTimeKind.Utc).AddTicks(3220), new Guid("5a8af4b4-8cb4-44ac-8291-010614601719") });
+
+            migrationBuilder.UpdateData(
+                table: "Persons",
+                keyColumn: "Id",
+                keyValue: new Guid("5a8af4b4-8cb4-44ac-8291-010614601719"),
+                columns: new[] { "Created", "Modified" },
+                values: new object[] { new DateTime(2023, 4, 1, 6, 39, 38, 67, DateTimeKind.Utc).AddTicks(3090), new DateTime(2023, 4, 1, 6, 39, 38, 67, DateTimeKind.Utc).AddTicks(3090) });
+        }
+    }
+}

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/UsersDatabase/Certification.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/UsersDatabase/Certification.cs
@@ -8,7 +8,7 @@ public class Certification : Auditable, IEntity
     public string? Name { get; set; }
 
     [Url]
-    public string? EscoUri { get; set; }
+    public List<string>? EscoUri { get; set; }
     
     [MaxLength(256)]
     public string? InstitutionName { get; set; }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/UsersDatabase/Certification.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/UsersDatabase/Certification.cs
@@ -6,9 +6,9 @@ public class Certification : Auditable, IEntity
 {
     [MaxLength(512)]
     public string? Name { get; set; }
-    
-    [MaxLength(256)]
-    public string? Type { get; set; }
+
+    [Url]
+    public string? EscoUri { get; set; }
     
     [MaxLength(256)]
     public string? InstitutionName { get; set; }

--- a/VirtualFinland.UsersAPI.UnitTests/Tests/Activities/Productizer/Builder/UpdateJobApplicantProfileCommandBuilder.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Tests/Activities/Productizer/Builder/UpdateJobApplicantProfileCommandBuilder.cs
@@ -10,7 +10,10 @@ public class UpdateJobApplicantProfileCommandBuilder
             new UpdateJobApplicantProfile.Request.Certification
             {
                 CertificationName = "Cloud provider certification",
-                EscoIdentifier = "http://data.europa.eu/esco/skill/b85711bc-32d6-42af-ae0f-e2e566d0dfca",
+                EscoIdentifier = new List<string>
+                {
+                    "http://data.europa.eu/esco/skill/b85711bc-32d6-42af-ae0f-e2e566d0dfca"
+                },
                 InstitutionName = "Skill Academy"
             }
         };

--- a/VirtualFinland.UsersAPI.UnitTests/Tests/Activities/Productizer/Builder/UpdateJobApplicantProfileCommandBuilder.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Tests/Activities/Productizer/Builder/UpdateJobApplicantProfileCommandBuilder.cs
@@ -9,8 +9,9 @@ public class UpdateJobApplicantProfileCommandBuilder
         {
             new UpdateJobApplicantProfile.Request.Certification
             {
-                CertificationName = "Hygiene passport",
-                QualificationType = "Institutional"
+                CertificationName = "Cloud provider certification",
+                EscoIdentifier = "http://data.europa.eu/esco/skill/b85711bc-32d6-42af-ae0f-e2e566d0dfca",
+                InstitutionName = "Skill Academy"
             }
         };
 
@@ -19,9 +20,11 @@ public class UpdateJobApplicantProfileCommandBuilder
         {
             new UpdateJobApplicantProfile.Request.Education
             {
+                EducationName = "Master chef",
                 EducationField = "0731",
                 EducationLevel = "7",
-                GraduationDate = new DateOnly(2022, 01, 31)
+                GraduationDate = new DateOnly(2022, 01, 31),
+                InstitutionName = "Chef School"
             }
         };
 
@@ -43,7 +46,8 @@ public class UpdateJobApplicantProfileCommandBuilder
             {
                 EscoCode = "2654.1.7",
                 EscoIdentifier = "http://data.europa.eu/esco/occupation/0022f466-426c-41a4-ac96-a235c945cf97",
-                WorkExperience = 1
+                WorkExperience = 1,
+                Employer = "VFD"
             }
         };
 


### PR DESCRIPTION
Oli näköjään joitain data definition muutoksia jäänyt tekemättä productizerihin, niin tässä pitäisi nyt olla testbedia vastaava setti. 

Vaikka conflussa olevassa tietokantamallissa on, että Certifications -> EscoUri on string, niin testbedin puolella tuo EscoUri on kuitenkin lista Uri-objekteja. Muutin tuon nyt niin, että kantaan menee kanssa lista Uri-objekteja.