### PR TITLE
We should break the key loading loop on successful load

### DIFF
--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Configurations/TestBedConsentProviderConfig.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Configurations/TestBedConsentProviderConfig.cs
@@ -55,6 +55,8 @@ public class TestBedConsentProviderConfig : IConsentProviderConfig
                     N = k.N,
                     E = k.E
                 }).ToList();
+                
+                break;
             }
             await Task.Delay(_configUrlRetryWaitTime);
         }


### PR DESCRIPTION
Käsittääkseni tuon loopin suorittamisen pitäisi keskytyä, kun on saatu avaimet ladattua, niin ei tarvitse turhaan odottaa kymmeniä sekunteja.