### PR TITLE
Feature/check if profiles are created when requesting data through productizer

### DIFF
--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/JobApplicantProfile/GetJobApplicantProfile.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/JobApplicantProfile/GetJobApplicantProfile.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Swashbuckle.AspNetCore.Annotations;
 using VirtualFinland.UserAPI.Data;
+using VirtualFinland.UserAPI.Exceptions;
 using VirtualFinland.UserAPI.Helpers;
 using VirtualFinland.UserAPI.Helpers.Swagger;
 
@@ -89,7 +90,7 @@ public static class GetJobApplicantProfile
                     person.WorkPreferences?.PreferredMunicipalityCode?.ToList() ?? new List<string>(),
                     person.WorkPreferences?.EmploymentTypeCode,
                     person.WorkPreferences?.WorkingTimeCode,
-                    person.WorkPreferences?.WorkingLanguageEnum?.ToList() ?? new List<string>()
+                    person.WorkPreferences?.WorkingLanguageEnum?.ToList() ?? throw new NotFoundException()
                 )
             };
         }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/JobApplicantProfile/GetJobApplicantProfile.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/JobApplicantProfile/GetJobApplicantProfile.cs
@@ -3,7 +3,6 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Swashbuckle.AspNetCore.Annotations;
 using VirtualFinland.UserAPI.Data;
-using VirtualFinland.UserAPI.Exceptions;
 using VirtualFinland.UserAPI.Helpers;
 using VirtualFinland.UserAPI.Helpers.Swagger;
 

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/JobApplicantProfile/GetJobApplicantProfile.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/JobApplicantProfile/GetJobApplicantProfile.cs
@@ -90,7 +90,7 @@ public static class GetJobApplicantProfile
                     person.WorkPreferences?.PreferredMunicipalityCode?.ToList() ?? new List<string>(),
                     person.WorkPreferences?.EmploymentTypeCode,
                     person.WorkPreferences?.WorkingTimeCode,
-                    person.WorkPreferences?.WorkingLanguageEnum?.ToList() ?? throw new NotFoundException()
+                    person.WorkPreferences?.WorkingLanguageEnum?.ToList() ?? new List<string>()
                 )
             };
         }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/ProductizerController.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/ProductizerController.cs
@@ -83,7 +83,7 @@ public class ProductizerController : ControllerBase
 
         var result = await _mediator.Send(new GetPersonBasicInformation.Query(userId));
 
-        if (!IsPersonBasicInformationCreated(result)) return NotFound();
+        if (!ProductizerProfileValidator.IsPersonBasicInformationCreated(result)) return NotFound();
 
         return Ok(result);
     }
@@ -121,7 +121,7 @@ public class ProductizerController : ControllerBase
 
         var result = await _mediator.Send(new GetJobApplicantProfile.Query(userId));
 
-        if (!IsJobApplicantProfileCreated(result)) return NotFound();
+        if (!ProductizerProfileValidator.IsJobApplicantProfileCreated(result)) return NotFound();
 
         return Ok(result);
     }
@@ -168,36 +168,5 @@ public class ProductizerController : ControllerBase
         }
 
         return userId;
-    }
-    
-    private static bool IsPersonBasicInformationCreated(
-        GetPersonBasicInformation.GetPersonBasicInformationResponse response)
-    {
-        if (!string.IsNullOrEmpty(response.Email) || !string.IsNullOrEmpty(response.Residency) ||
-            !string.IsNullOrEmpty(response.GivenName) || !string.IsNullOrEmpty(response.LastName) ||
-            !string.IsNullOrEmpty(response.PhoneNumber))
-            return true;
-
-
-        return false;
-    }
-
-    private static bool IsJobApplicantProfileCreated(PersonJobApplicantProfileResponse response)
-    {
-        if (response.Certifications.Any() || response.Educations.Any() || response.Occupations.Any() ||
-            response.Permits.Any() || response.LanguageSkills.Any() || response.OtherSkills.Any())
-            return true;
-
-        if (response.workPreferences.PreferredMunicipality.Any() ||
-            response.workPreferences.PreferredRegion.Any() ||
-            response.workPreferences.WorkingLanguage.Any())
-            return true;
-
-        if (!string.IsNullOrEmpty(response.workPreferences.WorkingTime) ||
-            !string.IsNullOrEmpty(response.workPreferences.NaceCode) ||
-            !string.IsNullOrEmpty(response.workPreferences.TypeOfEmployment))
-            return true;
-
-        return false;
     }
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/ProductizerProfileValidator.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/ProductizerProfileValidator.cs
@@ -1,0 +1,36 @@
+using VirtualFinland.UserAPI.Activities.Productizer.Operations.BasicInformation;
+using VirtualFinland.UserAPI.Activities.Productizer.Operations.JobApplicantProfile;
+
+namespace VirtualFinland.UserAPI.Activities.Productizer;
+
+public static class ProductizerProfileValidator
+{
+    public static bool IsPersonBasicInformationCreated(
+        GetPersonBasicInformation.GetPersonBasicInformationResponse response)
+    {
+        return !string.IsNullOrEmpty(response.Email);
+    }
+
+    public static bool IsJobApplicantProfileCreated(PersonJobApplicantProfileResponse response)
+    {
+        if (response.Certifications is { Count: > 0 } ||
+            response.Educations is { Count: > 0 } ||
+            response.Occupations is { Count: > 0 } ||
+            response.Permits is { Count: > 0 } ||
+            response.LanguageSkills is { Count: > 0 } ||
+            response.OtherSkills is { Count: > 0 })
+            return true;
+
+        if (response.workPreferences.PreferredMunicipality is { Count: > 0 } ||
+            response.workPreferences.PreferredRegion is { Count: > 0 } ||
+            response.workPreferences.WorkingLanguage is { Count: > 0 })
+            return true;
+
+        if (!string.IsNullOrEmpty(response.workPreferences.WorkingTime) ||
+            !string.IsNullOrEmpty(response.workPreferences.NaceCode) ||
+            !string.IsNullOrEmpty(response.workPreferences.TypeOfEmployment))
+            return true;
+
+        return false;
+    }
+}

--- a/VirtualFinland.UsersAPI.UnitTests/Tests/Activities/Productizer/Builder/PersonJobApplicantProfileResponseBuilder.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Tests/Activities/Productizer/Builder/PersonJobApplicantProfileResponseBuilder.cs
@@ -1,0 +1,72 @@
+using VirtualFinland.UserAPI.Activities.Productizer.Operations.JobApplicantProfile;
+
+namespace VirtualFinland.UsersAPI.UnitTests.Tests.Activities.Productizer.Builder;
+
+internal class PersonJobApplicantProfileResponseBuilder
+{
+    private readonly List<string> _permits = new();
+    private List<PersonJobApplicantProfileResponse.Certification> _certifications = new();
+    private List<PersonJobApplicantProfileResponse.Education> _educations = new();
+    private List<PersonJobApplicantProfileResponse.LanguageSkill> _languageSkills = new();
+    private List<PersonJobApplicantProfileResponse.Occupation> _occupations = new();
+    private List<PersonJobApplicantProfileResponse.OtherSkill> _otherSkills = new();
+
+    private PersonJobApplicantProfileResponse.WorkPreferences _workPreferences =
+        new PersonJobApplicantProfileResponseWorkPreferencesBuilder().Build();
+
+    public PersonJobApplicantProfileResponseBuilder WithCertifications(
+        List<PersonJobApplicantProfileResponse.Certification> value)
+    {
+        _certifications = value;
+        return this;
+    }
+
+    public PersonJobApplicantProfileResponseBuilder WithEducations(
+        List<PersonJobApplicantProfileResponse.Education> value)
+    {
+        _educations = value;
+        return this;
+    }
+
+    public PersonJobApplicantProfileResponseBuilder WithLanguageSkills(
+        List<PersonJobApplicantProfileResponse.LanguageSkill> value)
+    {
+        _languageSkills = value;
+        return this;
+    }
+
+    public PersonJobApplicantProfileResponseBuilder WithOccupations(
+        List<PersonJobApplicantProfileResponse.Occupation> value)
+    {
+        _occupations = value;
+        return this;
+    }
+
+    public PersonJobApplicantProfileResponseBuilder WithOtherSkills(
+        List<PersonJobApplicantProfileResponse.OtherSkill> value)
+    {
+        _otherSkills = value;
+        return this;
+    }
+
+    public PersonJobApplicantProfileResponseBuilder WithWorkPreferences(
+        PersonJobApplicantProfileResponse.WorkPreferences value)
+    {
+        _workPreferences = value;
+        return this;
+    }
+
+    public PersonJobApplicantProfileResponse Build()
+    {
+        return new PersonJobApplicantProfileResponse
+        {
+            Occupations = _occupations,
+            Educations = _educations,
+            LanguageSkills = _languageSkills,
+            OtherSkills = _otherSkills,
+            Certifications = _certifications,
+            Permits = _permits,
+            workPreferences = _workPreferences
+        };
+    }
+}

--- a/VirtualFinland.UsersAPI.UnitTests/Tests/Activities/Productizer/Builder/PersonJobApplicantProfileResponseWorkPreferencesBuilder.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Tests/Activities/Productizer/Builder/PersonJobApplicantProfileResponseWorkPreferencesBuilder.cs
@@ -1,0 +1,55 @@
+using VirtualFinland.UserAPI.Activities.Productizer.Operations.JobApplicantProfile;
+
+namespace VirtualFinland.UsersAPI.UnitTests.Tests.Activities.Productizer.Builder;
+
+internal class PersonJobApplicantProfileResponseWorkPreferencesBuilder
+{
+    private string? _naceCode = "42.323";
+    private List<string> _preferredMunicipality = new() { "405" };
+    private List<string> _preferredRegion = new() { "05" };
+    private string? _typeOfEmployment = "2";
+    private List<string> _workingLanguage = new() { "fi" };
+    private string? _workingTime = "01";
+
+    public PersonJobApplicantProfileResponseWorkPreferencesBuilder WithNaceCode(string? value)
+    {
+        _naceCode = value;
+        return this;
+    }
+
+    public PersonJobApplicantProfileResponseWorkPreferencesBuilder WithPreferredMunicipalities(List<string> value)
+    {
+        _preferredMunicipality = value;
+        return this;
+    }
+
+    public PersonJobApplicantProfileResponseWorkPreferencesBuilder WithPreferredRegions(List<string> value)
+    {
+        _preferredRegion = value;
+        return this;
+    }
+
+    public PersonJobApplicantProfileResponseWorkPreferencesBuilder WithEmploymentType(string? value)
+    {
+        _typeOfEmployment = value;
+        return this;
+    }
+
+    public PersonJobApplicantProfileResponseWorkPreferencesBuilder WithWorkingLanguage(List<string> value)
+    {
+        _workingLanguage = value;
+        return this;
+    }
+
+    public PersonJobApplicantProfileResponseWorkPreferencesBuilder WithWorkingTime(string? value)
+    {
+        _workingTime = value;
+        return this;
+    }
+
+    public PersonJobApplicantProfileResponse.WorkPreferences Build()
+    {
+        return new PersonJobApplicantProfileResponse.WorkPreferences(_naceCode, _preferredRegion,
+            _preferredMunicipality, _typeOfEmployment, _workingTime, _workingLanguage);
+    }
+}

--- a/VirtualFinland.UsersAPI.UnitTests/Tests/Activities/Productizer/ProductizerProfileValidator_UnitTests.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Tests/Activities/Productizer/ProductizerProfileValidator_UnitTests.cs
@@ -1,0 +1,141 @@
+using System.Text.Json;
+using FluentAssertions;
+using NSubstitute;
+using VirtualFinland.UserAPI.Activities.Productizer;
+using VirtualFinland.UserAPI.Activities.Productizer.Operations.JobApplicantProfile;
+using VirtualFinland.UsersAPI.UnitTests.Tests.Activities.Productizer.Builder;
+using Xunit.Abstractions;
+using PersonBasicInformationResponse =
+    VirtualFinland.UserAPI.Activities.Productizer.Operations.BasicInformation.GetPersonBasicInformation.GetPersonBasicInformationResponse;
+
+namespace VirtualFinland.UsersAPI.UnitTests.Tests.Activities.Productizer;
+
+// ReSharper disable once InconsistentNaming
+public class ProductizerProfileValidator_UnitTests
+{
+    private readonly ITestOutputHelper _helper;
+
+    public ProductizerProfileValidator_UnitTests(ITestOutputHelper helper)
+    {
+        _helper = helper;
+    }
+    
+    [Fact]
+    public void IsPersonBasicInformationCreated_WithEmailOnly_ShouldReturnTrue()
+    {
+        var response = new PersonBasicInformationResponse(null, null, "email@email.email", null, null);
+
+        var actual = ProductizerProfileValidator.IsPersonBasicInformationCreated(response);
+
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsPersonBasicInformationCreated_WithEverythingButEmail_ShouldReturnFalse()
+    {
+        var response = new PersonBasicInformationResponse(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            null,
+            Arg.Any<string>(),
+            Arg.Any<string>()
+        );
+
+        var actual = ProductizerProfileValidator.IsPersonBasicInformationCreated(response);
+
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsPersonBasicInformationCreated_WithNoData_ShouldReturnFalse()
+    {
+        var response = new PersonBasicInformationResponse(null, null, null, null, null);
+
+        var actual = ProductizerProfileValidator.IsPersonBasicInformationCreated(response);
+
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsPersonBasicInformationCreated_WithEmptyEmail_ShouldReturnFalse()
+    {
+        var response = new PersonBasicInformationResponse(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            "",
+            Arg.Any<string>(),
+            Arg.Any<string>()
+        );
+
+        var actual = ProductizerProfileValidator.IsPersonBasicInformationCreated(response);
+
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsPersonBasicInformationCreated_WithEmptyNameButValidEmail_ShouldReturnTrue()
+    {
+        var response = new PersonBasicInformationResponse(
+            "",
+            Arg.Any<string>(),
+            "email@email.email",
+            Arg.Any<string>(),
+            Arg.Any<string>()
+        );
+
+        var actual = ProductizerProfileValidator.IsPersonBasicInformationCreated(response);
+
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsJobApplicantProfileCreated_WithValidValues_ShouldReturnTrue()
+    {
+        var response = new PersonJobApplicantProfileResponseBuilder().Build();
+
+        var actual = ProductizerProfileValidator.IsJobApplicantProfileCreated(response);
+
+        actual.Should().BeTrue();
+        _helper.WriteLine(JsonSerializer.Serialize(response));
+    }
+
+    [Fact]
+    public void IsJobApplicantProfileCreated_OnlyRequiredData_ShouldReturnTrue()
+    {
+        var response = new PersonJobApplicantProfileResponseBuilder()
+            .WithCertifications(new List<PersonJobApplicantProfileResponse.Certification>
+                { new(null, new List<string> { "xyz" }, null) })
+            .WithWorkPreferences(
+                new PersonJobApplicantProfileResponseWorkPreferencesBuilder()
+                    .WithNaceCode(null)
+                    .WithEmploymentType(null)
+                    .WithWorkingTime(null)
+                    .Build())
+            .Build();
+        
+        var actual = ProductizerProfileValidator.IsJobApplicantProfileCreated(response);
+
+        actual.Should().BeTrue();
+        _helper.WriteLine(JsonSerializer.Serialize(response));
+    }
+
+    [Fact]
+    public void IsJobApplicantProfileCreated_WithNoActualData_ShouldReturnFalse()
+    {
+        var response = new PersonJobApplicantProfileResponseBuilder()
+            .WithWorkPreferences(new PersonJobApplicantProfileResponseWorkPreferencesBuilder()
+                .WithNaceCode(null)
+                .WithPreferredMunicipalities(new List<string>())
+                .WithPreferredRegions(new List<string>())
+                .WithWorkingLanguage(new List<string>())
+                .WithWorkingTime(null)
+                .WithEmploymentType(null)
+                .Build())
+            .Build();
+        
+        var actual = ProductizerProfileValidator.IsJobApplicantProfileCreated(response);
+
+        actual.Should().BeFalse();
+        _helper.WriteLine(JsonSerializer.Serialize(response));
+    }
+}


### PR DESCRIPTION
Muutoksia productizeriin
- PersonBasicInformation: Mikäli email tietoa ei ole asetettu, katsotaan data tuote puuttuvaksi, ja palautetaan 404
- JobApplicantProfile: Mikäli kaikki arrayt ovat tyhjät ja valinnainen data on null, katsotaan datatuote puuttuvaksi ja palautetaan 404