### PR TITLE
Handle aspnet validation errors with the exception handler

### DIFF
--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Exceptions/ValidationException.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Exceptions/ValidationException.cs
@@ -1,0 +1,23 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace VirtualFinland.UserAPI.Exceptions;
+
+public class ValidationException : Exception
+{
+    public ValidationException() : base() { }
+
+    public ValidationException(string message) : base(message) { }
+
+    public ValidationException(string message, params object[] args)
+        : base(String.Format(CultureInfo.CurrentCulture, message, args))
+    {
+    }
+
+    public ValidationException(ValidationProblemDetails validationProblemDetails) : base()
+    {
+        Errors = validationProblemDetails.Errors;
+    }
+
+    public IDictionary<string, string[]>? Errors { get; }
+}

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Exceptions/ValidationException.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Exceptions/ValidationException.cs
@@ -19,5 +19,10 @@ public class ValidationException : Exception
         Errors = validationProblemDetails.Errors;
     }
 
+    public ValidationException(IDictionary<string, string[]> errors) : base()
+    {
+        Errors = errors;
+    }
+
     public IDictionary<string, string[]>? Errors { get; }
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/ValidationProblemDetailsFactory.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/ValidationProblemDetailsFactory.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using VirtualFinland.UserAPI.Exceptions;
+
+namespace VirtualFinland.UserAPI.Helpers;
+
+public class ValidationProblemDetailsFactory : ProblemDetailsFactory
+{
+    public override ProblemDetails CreateProblemDetails(HttpContext httpContext, int? statusCode = null, string? title = null, string? type = null, string? detail = null, string? instance = null)
+    {
+        return new ProblemDetails
+        {
+            Status = statusCode,
+            Title = title,
+            Type = type,
+            Detail = detail,
+            Instance = instance
+        };
+    }
+
+    public override ValidationProblemDetails CreateValidationProblemDetails(HttpContext httpContext, ModelStateDictionary modelStateDictionary, int? statusCode = null, string? title = null, string? type = null, string? detail = null, string? instance = null)
+    {
+        var problemDetails = new ValidationProblemDetails(modelStateDictionary)
+        {
+            Type = type,
+            Title = title,
+            Status = 422,
+            Detail = detail,
+            Instance = instance
+        };
+        throw new ValidationException(problemDetails); // Pass the problem to the exception handler
+    }
+}

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Program.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Program.cs
@@ -15,6 +15,7 @@ using VirtualFinland.UserAPI.Middleware;
 using VirtualFinland.UserAPI.Helpers.Extensions;
 using VirtualFinland.UserAPI.Security.Extensions;
 using VirtualFinland.UserAPI.Helpers;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
@@ -109,6 +110,7 @@ builder.Services.AddTransient<TestbedConsentSecurityService>();
 // Route handlers
 //
 builder.Services.AddControllers();
+builder.Services.AddTransient<ProblemDetailsFactory, ValidationProblemDetailsFactory>();
 builder.Services.AddFluentValidation(new[] { Assembly.GetExecutingAssembly() });
 builder.Services.AddResponseCaching();
 


### PR DESCRIPTION
Muuttaa kontrollerin validaatiovirheviestin muodon dataspace:n speksin mukaiseksi:

- nyt myös 422-virheet sujautetaan ErrorHandlerMiddleware-käsittelijän kautta, kun aikaisemmin aspnet ohitti sen ja tulosti frameworkin defaultmuodon virheelle
- validaatiovirheviestin palauttama muoto nyt siis mallia:

```
{
  "detail": [
    {
      "loc": [
        "string",
        0
      ],
      "msg": "string",
      "type": "string"
    }
  ]
}
```
