### PR TITLE
Security token audience guard

### DIFF
--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/ProductizerController.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/ProductizerController.cs
@@ -159,7 +159,7 @@ public class ProductizerController : ControllerBase
                 e.Message);
             try
             {
-                var jwkToken = _authenticationService.ParseAuthenticationHeader(Request);
+                var jwkToken = await _authenticationService.ParseAuthenticationHeader(Request);
                 var query = new VerifyIdentityUser.Query(jwkToken.UserId, jwkToken.Issuer);
                 var createdUser = await _mediator.Send(query);
                 userId = createdUser.Id;

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Services/AuthenticationService.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Services/AuthenticationService.cs
@@ -18,7 +18,7 @@ public class AuthenticationService
         return person.Id;
     }
 
-    public JwtTokenResult ParseAuthenticationHeader(HttpRequest httpRequest)
+    public Task<JwtTokenResult> ParseAuthenticationHeader(HttpRequest httpRequest)
     {
         var token = httpRequest.Headers.Authorization.ToString().Replace("Bearer ", string.Empty);
         return _userSecurityService.ParseJwtToken(token);

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Services/UserSecurityService.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Services/UserSecurityService.cs
@@ -27,7 +27,7 @@ public class UserSecurityService
     /// <exception cref="NotAuthorizedException">If user id and the issuer are not found in the DB for any given user, this is not a valid user within the users database.</exception>
     public async Task<Person> VerifyAndGetAuthenticatedUser(string token)
     {
-        var jwtTokenResult = ParseJwtToken(token);
+        var jwtTokenResult = await ParseJwtToken(token);
 
         try
         {
@@ -44,7 +44,7 @@ public class UserSecurityService
     /// <summary>
     /// Parses the JWT token and returns the issuer and the user id
     /// </summary>
-    public JwtTokenResult ParseJwtToken(string token)
+    public Task<JwtTokenResult> ParseJwtToken(string token)
     {
         return _applicationSecurity.ParseJwtToken(token);
     }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/ApplicationSecurity.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/ApplicationSecurity.cs
@@ -30,8 +30,12 @@ public class ApplicationSecurity : IApplicationSecurity
         var tokenIssuer = parsedToken.Issuer;
         var securityFeature = _features.Find(o => o.Issuer == tokenIssuer) ?? throw new NotAuthorizedException("The given token issuer is not valid");
 
+        // Resolve and validate the token audience
+        var tokenAudience = parsedToken.Audiences.FirstOrDefault() ?? throw new NotAuthorizedException("The given token audience is not valid");
+        securityFeature.ValidateSecurityTokenAudience(tokenAudience);
+
         // Resolve user id
         var userId = securityFeature.ResolveTokenUserId(parsedToken) ?? throw new NotAuthorizedException("The given token claim is not valid");
-        return new JwtTokenResult { UserId = userId, Issuer = securityFeature.Issuer };
+        return new JwtTokenResult { UserId = userId, Issuer = securityFeature.Issuer, Audience = tokenAudience };
     }
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/ApplicationSecurity.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/ApplicationSecurity.cs
@@ -17,7 +17,7 @@ public class ApplicationSecurity : IApplicationSecurity
     /// <summary>
     /// Parses the JWT token and returns the issuer and the user id
     /// </summary>
-    public JwtTokenResult ParseJwtToken(string token)
+    public async Task<JwtTokenResult> ParseJwtToken(string token)
     {
         if (string.IsNullOrEmpty(token)) throw new NotAuthorizedException("No token provided");
 
@@ -32,7 +32,7 @@ public class ApplicationSecurity : IApplicationSecurity
 
         // Resolve and validate the token audience
         var tokenAudience = parsedToken.Audiences.FirstOrDefault() ?? throw new NotAuthorizedException("The given token audience is not valid");
-        securityFeature.ValidateSecurityTokenAudience(tokenAudience);
+        await securityFeature.ValidateSecurityTokenAudience(tokenAudience);
 
         // Resolve user id
         var userId = securityFeature.ResolveTokenUserId(parsedToken) ?? throw new NotAuthorizedException("The given token claim is not valid");

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Features/ISecurityFeature.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Features/ISecurityFeature.cs
@@ -10,6 +10,7 @@ public interface ISecurityFeature
     void BuildAuthorization(AuthorizationOptions options);
     string GetSecurityPolicySchemeName();
     string? ResolveTokenUserId(JwtSecurityToken jwtSecurityToken);
+    void ValidateSecurityTokenAudience(string audience);
 
-    public string? Issuer { get; }
+    public string Issuer { get; }
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Features/ISecurityFeature.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Features/ISecurityFeature.cs
@@ -10,7 +10,7 @@ public interface ISecurityFeature
     void BuildAuthorization(AuthorizationOptions options);
     string GetSecurityPolicySchemeName();
     string? ResolveTokenUserId(JwtSecurityToken jwtSecurityToken);
-    void ValidateSecurityTokenAudience(string audience);
+    Task ValidateSecurityTokenAudience(string audience);
 
     public string Issuer { get; }
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Features/SecurityFeature.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Features/SecurityFeature.cs
@@ -98,10 +98,13 @@ public class SecurityFeature : ISecurityFeature
     /// </summary>
     /// <param name="audience"></param>
     /// <exception cref="NotAuthorizedException"></exception>
-    public virtual void ValidateSecurityTokenAudience(string audience)
+    public virtual Task ValidateSecurityTokenAudience(string audience)
     {
-        if (!_options.AudienceGuardEnabled) return;
-        if (!_options.AllowedAudiences.Contains(audience)) throw new NotAuthorizedException("The given token audience is not allowed");
+        if (_options.AudienceGuardEnabled)
+        {
+            if (!_options.AllowedAudiences.Contains(audience)) throw new NotAuthorizedException("The given token audience is not allowed");
+        }
+        return Task.CompletedTask;
     }
 
     /// <summary>

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Features/SecurityFeature.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Features/SecurityFeature.cs
@@ -4,6 +4,8 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.IdentityModel.Tokens;
 using NetDevPack.Security.JwtExtensions;
+using VirtualFinland.UserAPI.Exceptions;
+using VirtualFinland.UserAPI.Security.Models;
 using JwksExtension = VirtualFinland.UserAPI.Helpers.Extensions.JwksExtension;
 
 namespace VirtualFinland.UserAPI.Security.Features;
@@ -13,7 +15,13 @@ public class SecurityFeature : ISecurityFeature
     ///
     /// The issuer of the JWT token
     ///
-    public string? Issuer { get; set; }
+    public string Issuer => _issuer ?? throw new ArgumentNullException("Issuer is not set");
+    protected string? _issuer;
+
+    /// <summary>
+    /// Security feature options
+    /// </summary>
+    protected SecurityFeatureOptions _options { get; set; }
 
     /// <summary>
     /// The URL to the OpenID configuration
@@ -35,15 +43,16 @@ public class SecurityFeature : ISecurityFeature
     /// </summary>
     protected const int _configUrlRetryWaitTime = 3000;
 
-    public SecurityFeature(SecurityFeatureOptions configuration)
+    public SecurityFeature(SecurityFeatureOptions options)
     {
-        Issuer = configuration.Issuer;
-        _openIDConfigurationURL = configuration.OpenIdConfigurationUrl;
-        _jwksOptionsUrl = configuration.AuthorizationJwksJsonUrl;
+        _options = options;
+        _issuer = options.Issuer;
+        _openIDConfigurationURL = options.OpenIdConfigurationUrl;
+        _jwksOptionsUrl = options.AuthorizationJwksJsonUrl;
 
         if (string.IsNullOrEmpty(_openIDConfigurationURL) && string.IsNullOrEmpty(_jwksOptionsUrl))
         {
-            throw new ArgumentNullException("Invalid security feature configuration");
+            throw new ArgumentException("Invalid security feature configuration");
         }
     }
 
@@ -85,6 +94,17 @@ public class SecurityFeature : ISecurityFeature
     }
 
     /// <summary>
+    /// Validates the token audience
+    /// </summary>
+    /// <param name="audience"></param>
+    /// <exception cref="NotAuthorizedException"></exception>
+    public virtual void ValidateSecurityTokenAudience(string audience)
+    {
+        if (!_options.AudienceGuardEnabled) return;
+        if (!_options.AllowedAudiences.Contains(audience)) throw new NotAuthorizedException("The given token audience is not allowed");
+    }
+
+    /// <summary>
     /// Configures the OpenID Connect authentication
     /// </summary>
     protected virtual void ConfigureOpenIdConnect(AuthenticationBuilder authentication)
@@ -118,10 +138,10 @@ public class SecurityFeature : ISecurityFeature
             if (httpResponse.IsSuccessStatusCode)
             {
                 var jsonData = JsonNode.Parse(await httpResponse.Content.ReadAsStringAsync());
-                Issuer = jsonData?["issuer"]?.ToString();
+                _issuer = jsonData?["issuer"]?.ToString();
                 _jwksOptionsUrl = jsonData?["jwks_uri"]?.ToString();
 
-                if (!string.IsNullOrEmpty(Issuer) && !string.IsNullOrEmpty(_jwksOptionsUrl))
+                if (!string.IsNullOrEmpty(_issuer) && !string.IsNullOrEmpty(_jwksOptionsUrl))
                 {
                     break;
                 }
@@ -130,7 +150,7 @@ public class SecurityFeature : ISecurityFeature
         }
 
         // If all retries fail, then send an exception since the security information is critical to the functionality of the backend
-        if (string.IsNullOrEmpty(Issuer) || string.IsNullOrEmpty(_jwksOptionsUrl))
+        if (string.IsNullOrEmpty(_issuer) || string.IsNullOrEmpty(_jwksOptionsUrl))
         {
             throw new ArgumentNullException("Failed to retrieve OpenID configurations");
         }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Features/SinunaSecurityFeature.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Features/SinunaSecurityFeature.cs
@@ -1,4 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
+using VirtualFinland.UserAPI.Exceptions;
+using VirtualFinland.UserAPI.Security.Models;
 
 namespace VirtualFinland.UserAPI.Security.Features;
 

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Features/SuomiFiSecurityFeature.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Features/SuomiFiSecurityFeature.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.IdentityModel.Tokens;
 using NetDevPack.Security.JwtExtensions;
+using VirtualFinland.UserAPI.Security.Models;
 using JwksExtension = VirtualFinland.UserAPI.Helpers.Extensions.JwksExtension;
 
 namespace VirtualFinland.UserAPI.Security.Features;

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Features/TestbedSecurityFeature.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Features/TestbedSecurityFeature.cs
@@ -1,3 +1,5 @@
+using VirtualFinland.UserAPI.Security.Models;
+
 namespace VirtualFinland.UserAPI.Security.Features;
 
 public class TestbedSecurityFeature : SecurityFeature

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/IApplicationSecurity.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/IApplicationSecurity.cs
@@ -2,5 +2,5 @@ namespace VirtualFinland.UserAPI.Security.Models;
 
 public interface IApplicationSecurity
 {
-    JwtTokenResult ParseJwtToken(string token);
+    Task<JwtTokenResult> ParseJwtToken(string token);
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Models/JwtTokenResult.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Models/JwtTokenResult.cs
@@ -2,6 +2,7 @@ namespace VirtualFinland.UserAPI.Security.Models;
 
 public class JwtTokenResult
 {
-    public string? UserId { get; set; }
-    public string? Issuer { get; set; }
+    public string UserId { get; set; } = default!;
+    public string Issuer { get; set; } = default!;
+    public string Audience { get; set; } = default!;
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Models/SecurityFeatureOptions.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Models/SecurityFeatureOptions.cs
@@ -1,7 +1,11 @@
+namespace VirtualFinland.UserAPI.Security.Models;
+
 public class SecurityFeatureOptions
 {
     public string? OpenIdConfigurationUrl { get; set; }
     public string? AuthorizationJwksJsonUrl { get; set; }
-    public string? Issuer { get; set; }
+    public string? Issuer { get; set; } = default!;
     public bool IsEnabled { get; set; }
+    public List<string> AllowedAudiences { get; set; } = new List<string>();
+    public bool AudienceGuardEnabled { get; set; } = false;
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.json
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.json
@@ -33,16 +33,22 @@
         "ConsentJwksJsonUrl": "https://consent.testbed.fi/.well-known/jwks.json",
         "ConsentIssuer": "https://consent.testbed.fi",
         "ConsentVerifyUrl": "https://consent.testbed.fi/Consent/Verify",
-        "IsEnabled": false
+        "IsEnabled": false,
+        "AllowedAudiences": [],
+        "AudienceGuardEnabled": false
       },
       "Sinuna": {
         "OpenIDConfigurationURL": "https://login.iam.qa.sinuna.fi/oxauth/.well-known/openid-configuration",
-        "IsEnabled": false
+        "IsEnabled": false,
+        "AllowedAudiences": [],
+        "AudienceGuardEnabled": false
       },
       "SuomiFi": {
         "AuthorizationJwksJsonUrl": "http://localhost:4078/auth/saml2/suomifi/.well-known/jwks.json",
         "Issuer": "virtual-finland/authentication-gw/suomifi",
-        "IsEnabled": false
+        "IsEnabled": false,
+        "AllowedAudiences": [],
+        "AudienceGuardEnabled": false
       }
     }
   },

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.local.json
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.local.json
@@ -28,7 +28,9 @@
         "IsEnabled": true
       },
       "Sinuna": {
-        "IsEnabled": true
+        "IsEnabled": true,
+        "AllowedAudiences": [],
+        "AudienceGuardEnabled": false
       },
       "SuomiFi": {
         "IsEnabled": true

--- a/VirtualFinland.UsersAPI.UnitTests/Tests/Security/AuthenticationTests.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Tests/Security/AuthenticationTests.cs
@@ -12,6 +12,7 @@ using VirtualFinland.UserAPI.Security.Features;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using Microsoft.IdentityModel.Tokens;
+using VirtualFinland.UserAPI.Security.Models;
 
 namespace VirtualFinland.UsersAPI.UnitTests.Tests.Security;
 


### PR DESCRIPTION
- allows a security feature to validate the audience claim
  - default implementation uses static build-time config as a source for allowed audience values:
    - 
    ```
    { ...
    "AllowedAudiences": [],
    "AudienceGuardEnabled": false,
    ... }
    ``` 
  - by default the checks are disabled
  - could be extended to check the audience against external services. For example:
    - validating the audience is registered in the dataspace
- adds the audience detail to the [JwtTokenResult](https://github.com/Virtual-Finland-Development/users-api/blob/78282dec2aec03faeb6f390c79109fdea7ba6d1a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Models/JwtTokenResult.cs) where it could be used in for example in pinpointing which external service accessed the data in use-cases like:
  - logging
  - features like the proposed terms of service productizer: https://github.com/Virtual-Finland-Development/users-api/pull/73