### PR TITLE
Case-insensitive admin function argument names

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Invoke database migration runner lambda
         if: ${{ steps.deployment-database-events.outputs.Migrations == 'true' }}
         run: |
-          aws lambda invoke --payload '{"Action": "Migrate"}' --cli-binary-format raw-in-base64-out --function-name ${{ steps.get-pulumi-outputs.outputs.AdminFunctionArn }} output.json
+          aws lambda invoke --payload '{"action": "migrate"}' --cli-binary-format raw-in-base64-out --function-name ${{ steps.get-pulumi-outputs.outputs.AdminFunctionArn }} output.json
           cat output.json
       - name: Tag the deployment
         uses: Virtual-Finland-Development/automatic-release-action@v1.0

--- a/Docs/README.adminfunction.md
+++ b/Docs/README.adminfunction.md
@@ -7,7 +7,7 @@ The administration tool [../VirtualFinland.UsersAPI.AdminFunction](../VirtualFin
 With correct aws credentials in place the admin function can be invoked using the aws cli, for example a database migration can be run with the following command:
 
 ```
-aws lambda invoke --payload '{"Action": "Migrate"}' --cli-binary-format raw-in-base64-out --function-name $(pulumi stack output AdminFunctionArn) output.json
+aws lambda invoke --payload '{"action": "migrate"}' --cli-binary-format raw-in-base64-out --function-name $(pulumi stack output AdminFunctionArn) output.json
 ```
 
 - where the `--payload` is the json payload that is passed to the function
@@ -31,8 +31,8 @@ dotnet run --project ./VirtualFinland.UsersAPI.AdminFunction.CLI migrate
 ## Available actions
 
 - `migrate` - runs the database migrations
-  - lambda function payload: `{"Action": "Migrate"}`
+  - lambda function payload: `{"action": "migrate"}`
   - cli command: `dotnet run --project ./VirtualFinland.UsersAPI.AdminFunction.CLI migrate`
 - `initialize-database-user` - setup the application-level user credentials to the database
-  - lambda function payload: `{"Action": "InitializeDatabaseUser", "data": "{\"Username\": \"appuser\", \"Password\": \"pass\"}"}`
+  - lambda function payload: `{"action": "initialize-database-user", "data": "{\"username\": \"appuser\", \"password\": \"pass\"}"}`
   - cli command: `DATABASE_USER=appuser DATABASE_PASSWORD=pass dotnet run --project ./VirtualFinland.UsersAPI.AdminFunction.CLI initialize-database-user`

--- a/Docs/README.database.md
+++ b/Docs/README.database.md
@@ -42,10 +42,10 @@ var rdsPostGreInstance = new Instance(instanceName, new InstanceArgs()
 1. Resolve the pulumi stack output for the database migrator lambda function ARN: `AdminFunctionArn`
 2. Invoke the function:
 
-- with AWS CLI: `aws lambda invoke --payload '{"Action": "Migrate"}' --cli-binary-format raw-in-base64-out --function-name <AdminFunctionArn> output.json`
+- with AWS CLI: `aws lambda invoke --payload '{"action": "migrate"}' --cli-binary-format raw-in-base64-out --function-name <AdminFunctionArn> output.json`
 - or by using the AWS Console:
   - Go to AWS Console and select Lambda
   - Select the function with name like `users-api-AdminFunction-<stage>-<random-hash>`
   - Select the tab "Test"
-  - Add a new test event with the following content: `{"Action": "Migrate"}`
+  - Add a new test event with the following content: `{"action": "migrate"}`
   - Click "Test" button and wait for the execution to finish

--- a/Docs/README.deployment.md
+++ b/Docs/README.deployment.md
@@ -13,10 +13,10 @@ Deployment to a fresh environment requires the following steps to be performed i
     - `pulumi up`
 - manually run the initial database migrations:
   - with a oneliner (with the correct AWS Profile):
-    - `aws lambda invoke --payload '{"Action": "Migrate"}' --cli-binary-format raw-in-base64-out --function-name $(pulumi stack output AdminFunctionArn) output.json`
+    - `aws lambda invoke --payload '{"action": "migrate"}' --cli-binary-format raw-in-base64-out --function-name $(pulumi stack output AdminFunctionArn) output.json`
   - or by using the AWS Console:
     - Go to AWS Console and select Lambda
     - Select the function with name like `users-api-AdminFunctionArn-<stage>-<random-hash>`
     - Select the tab "Test"
-    - Add a new test event with the following content: `{"Action": "Migrate"}`
+    - Add a new test event with the following content: `{"action": "migrate"}`
     - Click "Test" button and wait for the execution to finish

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/VirtualFinland.UsersAPI.csproj
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/VirtualFinland.UsersAPI.csproj
@@ -20,7 +20,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.3.1" />
-    <PackageReference Include="AWSSDK.SecretsManager.Caching" Version="1.0.5" />
+    <PackageReference Include="AWSSDK.SecretsManager.Caching" Version="1.0.6" />
     <PackageReference Include="FluentValidation" Version="11.2.2" />
     <PackageReference Include="ISO3166" Version="1.0.4" />
     <PackageReference Include="MediatR" Version="11.0.0" />

--- a/VirtualFinland.UsersAPI.AdminFunction/Converters/CaseInsensitiveLambdaJsonSerializer.cs
+++ b/VirtualFinland.UsersAPI.AdminFunction/Converters/CaseInsensitiveLambdaJsonSerializer.cs
@@ -1,0 +1,21 @@
+using System.Text.Json;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace VirtualFinland.Converters;
+
+public class CaseInsensitiveLambdaJsonSerializer : DefaultLambdaJsonSerializer
+{
+    /// <summary>
+    /// Constructs instance of serializer.
+    /// </summary>
+    public CaseInsensitiveLambdaJsonSerializer()
+        : base(ConfigureJsonSerializerOptions)
+    {
+
+    }
+
+    private static void ConfigureJsonSerializerOptions(JsonSerializerOptions options)
+    {
+        options.PropertyNameCaseInsensitive = true;
+    }
+}

--- a/VirtualFinland.UsersAPI.AdminFunction/Function.cs
+++ b/VirtualFinland.UsersAPI.AdminFunction/Function.cs
@@ -3,7 +3,8 @@ using VirtualFinland.UserAPI.Data;
 using VirtualFinland.AdminFunction.AdminApp;
 using VirtualFinland.AdminFunction.AdminApp.Models;
 using Amazon.Lambda.Core;
-[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+using VirtualFinland.Converters;
+[assembly: LambdaSerializer(typeof(CaseInsensitiveLambdaJsonSerializer))]
 
 namespace VirtualFinland.AdminFunction;
 

--- a/VirtualFinland.UsersAPI.Deployment/Features/PostgresDatabase.cs
+++ b/VirtualFinland.UsersAPI.Deployment/Features/PostgresDatabase.cs
@@ -170,7 +170,7 @@ public class PostgresDatabase
             {
                 var invokePayload = JsonSerializer.Serialize(new
                 {
-                    action = "InitializeDatabaseUser",
+                    action = "initialize-database-user",
                     data = JsonSerializer.Serialize(new
                     {
                         Username = DbUsername,


### PR DESCRIPTION
- Allows case-insensitive naming of the admin function input payload field names so for the benefits: 
 - we're not enforced to use c#-style names outside of the c#-scope
 - allows consistent naming on the lambda-function action-payloads and the command-line app commands 