### PR TITLE
Subscribe errors to the monitoring/alerter

### DIFF
--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/GetSearchProfile.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/GetSearchProfile.cs
@@ -51,7 +51,6 @@ public static class GetSearchProfile
 
             if (userSearchProfile is null)
             {
-                _logger.LogInformation("Failed to retrieve search profile: {RequestProfileId}", request.ProfileId);
                 throw new NotFoundException($"Specified search profile not found by ID: {request.ProfileId}");
             }
 

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Services/TestbedConsentSecurityService.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Services/TestbedConsentSecurityService.cs
@@ -24,7 +24,7 @@ public class TestbedConsentSecurityService
 
     public async Task VerifyConsentTokenRequestHeaders(IHeaderDictionary headers, string dataSourceUri)
     {
-        _logger.LogInformation("Verifying consent request");
+        _logger.LogDebug("Verifying consent request");
         var idToken = headers.Authorization.ToString().Replace("Bearer ", string.Empty);
         if (string.IsNullOrEmpty(idToken))
             throw new NotAuthorizedException("Authorization token is missing");
@@ -36,12 +36,12 @@ public class TestbedConsentSecurityService
         VerifyConsentToken(consentToken, idToken, dataSourceUri);
         await VerifyConsentTokenWithService(consentToken, idToken, dataSourceUri); // Checks for token revokation
 
-        _logger.LogInformation("Consent request verified");
+        _logger.LogDebug("Consent request verified");
     }
 
     public void VerifyConsentToken(string consentTokenRaw, string idTokenRaw, string dataSourceUri)
     {
-        _logger.LogInformation("Verifying consent token");
+        _logger.LogDebug("Verifying consent token");
 
         var idToken = ParseJwtToken(idTokenRaw);
         if (idToken == null)
@@ -96,13 +96,13 @@ public class TestbedConsentSecurityService
         if (consentToken.Payload["dsi"] as string != dataSourceUri)
             throw new NotAuthorizedException("Token mismatch: dsi");
 
-        _logger.LogInformation("Consent token verified");
+        _logger.LogDebug("Consent token verified");
     }
 
 
     public async Task VerifyConsentTokenWithService(string consentToken, string idToken, string dataSourceUri)
     {
-        _logger.LogInformation("Verifying consent with Testbed Consent API");
+        _logger.LogDebug("Verifying consent with Testbed Consent API");
         try
         {
             var httpClient = _httpClientFactory.CreateClient();
@@ -130,7 +130,7 @@ public class TestbedConsentSecurityService
             throw new NotAuthorizedException(e.Message);
         }
 
-        _logger.LogInformation("Consent verified by Testbed Consent API");
+        _logger.LogDebug("Consent verified by Testbed Consent API");
     }
 
 

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Middleware/ErrorHandlerMiddleware.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Middleware/ErrorHandlerMiddleware.cs
@@ -23,6 +23,10 @@ public class ErrorHandlerMiddleware
         }
         catch (Exception error)
         {
+            // Attach exception to the request context for request logger middleware
+            context.Items.Add("Exception", error);
+
+            // Write the error response
             switch (error)
             {
                 case NotAuthorizedException:

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Middleware/ErrorHandlerMiddleware.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Middleware/ErrorHandlerMiddleware.cs
@@ -23,6 +23,9 @@ public class ErrorHandlerMiddleware
         }
         catch (Exception error)
         {
+            // Debug mode logging
+            _logger.LogDebug(error, "Debug");
+
             // Attach exception to the request context for request logger middleware
             context.Items.Add("Exception", error);
 
@@ -44,7 +47,6 @@ public class ErrorHandlerMiddleware
                     }, HttpStatusCode.NotFound);
                     break;
                 case BadRequestException:
-                    _logger.LogError(error, "Request processing failure!");
                     await WriteErrorResponse(context, new ErrorResponse()
                     {
                         Type = "BadRequest",
@@ -110,7 +112,6 @@ public class ErrorHandlerMiddleware
                     }
                     break;
                 default:
-                    _logger.LogError(error, "Request processing failure!");
                     await WriteErrorResponse(context, new ErrorResponse()
                     {
                         Type = "InternalServerError",

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Program.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Program.cs
@@ -171,7 +171,17 @@ if (!EnvironmentExtensions.IsProduction(app.Environment))
 }
 
 
-app.UseSerilogRequestLogging();
+app.UseSerilogRequestLogging(options =>
+{
+    options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
+    {
+        if (httpContext.Items["Exception"] is Exception exception)
+        {
+            // Add the exception to the log context, omit the stack trace
+            diagnosticContext.Set("$x", $"{exception.GetType().Name}: {exception.Message}");
+        }
+    };
+});
 app.UseMiddleware<RequestTracingMiddleware>();
 app.UseMiddleware<ErrorHandlerMiddleware>();
 app.UseHttpsRedirection();

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Program.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Program.cs
@@ -178,7 +178,7 @@ app.UseSerilogRequestLogging(options =>
         if (httpContext.Items["Exception"] is Exception exception)
         {
             // Add the exception to the log context, omit the stack trace
-            diagnosticContext.Set("$x", $"{exception.GetType().Name}: {exception.Message}");
+            diagnosticContext.Set("@x", $"{exception.GetType().Name}: {exception.Message}");
         }
     };
 });

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.dev.json
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.dev.json
@@ -1,26 +1,4 @@
 {
-  "Serilog": {
-    "Using": [
-      "Serilog.Sinks.Console"
-    ],
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Warning",
-        "Microsoft.AspNetCore": "Warning",
-        "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
-      }
-    },
-    "WriteTo": [
-      {
-        "Name": "Console",
-        "Args": {
-          "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact"
-        }
-      }
-    ]
-  },
   "Security": {
     "Authorization": {
       "SuomiFi": {

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.dev.json
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.dev.json
@@ -16,7 +16,7 @@
       {
         "Name": "Console",
         "Args": {
-          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+          "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact"
         }
       }
     ]

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.json
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.json
@@ -5,6 +5,28 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.Console"
+    ],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Warning",
+        "Microsoft.AspNetCore": "Warning",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact"
+        }
+      }
+    ]
+  },
   "AllowedHosts": "*",
   "Security": {
     "Access": {

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.local.json
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.local.json
@@ -1,6 +1,7 @@
 {
   "Serilog": {
     "MinimumLevel": {
+      "Default": "Debug",
       "Override": {
         "Microsoft.EntityFrameworkCore.Database.Command": "Information"
       }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.local.json
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.local.json
@@ -1,20 +1,17 @@
 {
   "Serilog": {
-    "Using": [
-      "Serilog.Sinks.Console"
-    ],
     "MinimumLevel": {
-      "Default": "Information",
       "Override": {
-        "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Warning",
-        "Microsoft.AspNetCore": "Warning",
-        "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
+        "Microsoft.EntityFrameworkCore.Database.Command": "Information"
       }
     },
     "WriteTo": [
       {
-        "Name": "Console"
+        "Name": "Console",
+        "Args": {
+          "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console",
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"
+        }
       }
     ]
   },

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.mvp-staging.json
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.mvp-staging.json
@@ -1,26 +1,4 @@
 {
-  "Serilog": {
-    "Using": [
-      "Serilog.Sinks.Console"
-    ],
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Warning",
-        "Microsoft.AspNetCore": "Warning",
-        "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
-      }
-    },
-    "WriteTo": [
-      {
-        "Name": "Console",
-        "Args": {
-          "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact"
-        }
-      }
-    ]
-  },
   "Security": {
     "Authorization": {
       "Sinuna": {

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.mvp-staging.json
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.mvp-staging.json
@@ -16,7 +16,7 @@
       {
         "Name": "Console",
         "Args": {
-          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+          "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact"
         }
       }
     ]

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.staging.json
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.staging.json
@@ -1,26 +1,4 @@
 {
-  "Serilog": {
-    "Using": [
-      "Serilog.Sinks.Console"
-    ],
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Warning",
-        "Microsoft.AspNetCore": "Warning",
-        "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
-      }
-    },
-    "WriteTo": [
-      {
-        "Name": "Console",
-        "Args": {
-          "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact"
-        }
-      }
-    ]
-  },
   "Security": {
     "Authorization": {
       "SuomiFi": {

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.staging.json
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.staging.json
@@ -16,7 +16,7 @@
       {
         "Name": "Console",
         "Args": {
-          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+          "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact"
         }
       }
     ]

--- a/VirtualFinland.UsersAPI.Deployment/Common/Models/StackSetup.cs
+++ b/VirtualFinland.UsersAPI.Deployment/Common/Models/StackSetup.cs
@@ -12,4 +12,5 @@ public class StackSetup
     public string Region = default!;
     public string CreateResourceName(string name) => $"{ProjectName}-{name}-{Environment}".ToLower();
     public string GetInfrastructureStackName() => $"{Organization}/infrastructure/{Environment}";
+    public string GetAlertingStackName() => $"{Organization}/cloudwatch-logs-alerts/{Environment}";
 }

--- a/VirtualFinland.UsersAPI.Deployment/Features/UsersApiLambdaFunction.cs
+++ b/VirtualFinland.UsersAPI.Deployment/Features/UsersApiLambdaFunction.cs
@@ -116,7 +116,7 @@ class UsersApiLambdaFunction
             Role = execRole.Arn,
             Runtime = "dotnet6",
             Handler = "VirtualFinland.UsersAPI",
-            Timeout = 30,
+            Timeout = 10,
             MemorySize = 2048,
             Environment = new FunctionEnvironmentArgs
             {

--- a/VirtualFinland.UsersAPI.Deployment/Features/UsersApiLambdaFunction.cs
+++ b/VirtualFinland.UsersAPI.Deployment/Features/UsersApiLambdaFunction.cs
@@ -197,7 +197,7 @@ class UsersApiLambdaFunction
         _ = new LogSubscriptionFilter(stackSetup.CreateResourceName("StatusCodeAlert"), new LogSubscriptionFilterArgs
         {
             LogGroup = LogGroup.Name,
-            FilterPattern = "{ $.StatusCode > 401 }", // Users API should not encounter errors with status code > 401, for example validation errors not expected
+            FilterPattern = "{ $.StatusCode > 404 }", // Users API should not encounter errors with status code > 404, for example validation errors not expected
             DestinationArn = errorLambdaFunctionArn,
         }, new() { DependsOn = { logGroupInvokePermission } });
 

--- a/VirtualFinland.UsersAPI.Deployment/Features/UsersApiLambdaFunction.cs
+++ b/VirtualFinland.UsersAPI.Deployment/Features/UsersApiLambdaFunction.cs
@@ -116,7 +116,7 @@ class UsersApiLambdaFunction
             Role = execRole.Arn,
             Runtime = "dotnet6",
             Handler = "VirtualFinland.UsersAPI",
-            Timeout = 10,
+            Timeout = 15,
             MemorySize = 2048,
             Environment = new FunctionEnvironmentArgs
             {


### PR DESCRIPTION
- sends alerts to the monitoring when:
  - the http response code is above 404, that primarily includes: 
    - server errors
    - validation errors
  - lambda function timeouts
- drop the lambda function timeout from 30s to 15s:
  - should the users-api response time be above 15 seconds, an error it be considered as should
- adds exception type and message to the request log (payload that's send to the alerter)
- simplifies the logging configurations regarding live environments
- relates to https://github.com/Virtual-Finland-Development/monitoring/pull/28