### PR TITLE
Run the local development initializations in isolated container

### DIFF
--- a/VirtualFinland.UsersAPI.AdminFunction.CLI/Dockerfile
+++ b/VirtualFinland.UsersAPI.AdminFunction.CLI/Dockerfile
@@ -1,0 +1,3 @@
+﻿FROM mcr.microsoft.com/dotnet/sdk:6.0
+WORKDIR /app
+COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,10 +26,10 @@ services:
       - "host.docker.internal:host-gateway"
 
   usersapi-local-initialization:
-    image: mcr.microsoft.com/dotnet/sdk:6.0
-    volumes:
-      - ./:/app
-    working_dir: /app
+    image: virtualfinland/usersapi-adminfunction-cli:latest
+    build:
+      context: ./
+      dockerfile: ./VirtualFinland.UsersAPI.AdminFunction.CLI/Dockerfile
     command: >
       bash -c "
         set -e


### PR DESCRIPTION
- docker-compose script `usersapi-local-initialization` runs now without using bind-mounts
  - no longer touches the hosts dotnet project binaries (no need to locally run `dotnet restore` after docker brought up)
  - docker compose no longer messes up the code editor linter situation 