### PR TITLE
Fix bad Terms-of-Service refactoring / merging

### DIFF
--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/UserController.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/UserController.cs
@@ -161,7 +161,7 @@ public class UserController : ApiControllerBase
     [ProducesErrorResponseType(typeof(ProblemDetails))]
     public async Task<IActionResult> GetPersonTermsOfServiceAgreement()
     {
-        var authenticated = await AuthenticateOrRegisterPerson();
+        var authenticated = await AuthenticateOrRegisterPerson(false);
         return Ok(await _mediator.Send(new GetPersonServiceTermsAgreement.Query(authenticated)));
     }
 

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/APIControllerBase.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/APIControllerBase.cs
@@ -23,11 +23,11 @@ public class ApiControllerBase : ControllerBase
         return await _authenticationService.Authenticate(HttpContext, verifyTermsOfServiceAgreement);
     }
 
-    protected async Task<RequestAuthenticatedUser> AuthenticateOrRegisterPerson()
+    protected async Task<RequestAuthenticatedUser> AuthenticateOrRegisterPerson(bool verifyTermsOfServiceAgreement = true)
     {
         try
         {
-            return await _authenticationService.Authenticate(HttpContext);
+            return await _authenticationService.Authenticate(HttpContext, verifyTermsOfServiceAgreement);
         }
         catch (NotFoundException)
         {

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Services/AuthenticationService.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Services/AuthenticationService.cs
@@ -35,7 +35,7 @@ public class AuthenticationService
 
         try
         {
-            var externalIdentity = await _usersDbContext.ExternalIdentities.SingleAsync(o => o.IdentityId == requestAuthenticationCandinate.IdentityId && o.Issuer == requestAuthenticationCandinate.Issuer, CancellationToken.None);
+            var externalIdentity = await _usersDbContext.ExternalIdentities.SingleAsync(o => o.IdentityId == requestAuthenticationCandinate.IdentityId && o.Issuer == requestAuthenticationCandinate.Issuer, cancellationToken);
             var person = await _usersDbContext.Persons.SingleAsync(o => o.Id == externalIdentity.UserId, cancellationToken);
             if (verifyTermsOfServiceAgreement) await _applicationSecurity.VerifyPersonTermsOfServiceAgreement(person.Id);
 

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/ApplicationSecurity.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/ApplicationSecurity.cs
@@ -1,8 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
-using Microsoft.Extensions.Options;
 using VirtualFinland.UserAPI.Data.Repositories;
 using VirtualFinland.UserAPI.Exceptions;
-using VirtualFinland.UserAPI.Security.Features;
 using VirtualFinland.UserAPI.Security.Models;
 
 namespace VirtualFinland.UserAPI.Security;

--- a/VirtualFinland.UsersAPI.UnitTests/Helpers/APITestBase.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Helpers/APITestBase.cs
@@ -9,6 +9,7 @@ using Moq;
 using VirtualFinland.UserAPI.Data;
 using VirtualFinland.UserAPI.Data.Repositories;
 using VirtualFinland.UserAPI.Helpers.Services;
+using VirtualFinland.UserAPI.Models.UsersDatabase;
 using VirtualFinland.UserAPI.Security;
 using VirtualFinland.UserAPI.Security.Configurations;
 using VirtualFinland.UserAPI.Security.Features;
@@ -33,7 +34,7 @@ public class APITestBase
         return new UsersDbContext(options, true);
     }
 
-    public (IRequestAuthenticationCandinate requestAuthenticationCandinate, AuthenticationService authenticationService, Mock<HttpContext> httpContext) GetGoodLoginRequestSituation(IRequestAuthenticationCandinate requestAuthenticationCandinate)
+    public (IRequestAuthenticationCandinate requestAuthenticationCandinate, AuthenticationService authenticationService, Mock<HttpContext> httpContext) GetGoodLoginRequestSituation(IRequestAuthenticationCandinate requestAuthenticationCandinate, bool verifyTermsOfServiceAgreement = false)
     {
         // Create mock jwt token
         var idToken = new JwtSecurityTokenHandler().WriteToken(new JwtSecurityToken(
@@ -79,7 +80,7 @@ public class APITestBase
                 },
                 Options = new SecurityOptions()
                 {
-                    TermsOfServiceAgreementRequired = false
+                    TermsOfServiceAgreementRequired = verifyTermsOfServiceAgreement
                 }
             }
         );
@@ -116,5 +117,19 @@ public class APITestBase
             .Returns(serviceScopeFactory.Object);
 
         return serviceProvider;
+    }
+
+    protected async Task<TermsOfService> SetupTermsOfServices()
+    {
+        var termsOfServicesData = TermsOfServiceBuilder.Build();
+        var tos = await _dbContext.TermsOfServices.SingleOrDefaultAsync(tos => tos.Version == termsOfServicesData.Version);
+        if (tos != null)
+        {
+            return tos;
+        }
+
+        var entry = _dbContext.TermsOfServices.Add(termsOfServicesData);
+        await _dbContext.SaveChangesAsync();
+        return entry.Entity;
     }
 }

--- a/VirtualFinland.UsersAPI.UnitTests/Helpers/TermsOfServiceBuilder.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Helpers/TermsOfServiceBuilder.cs
@@ -1,0 +1,16 @@
+using VirtualFinland.UserAPI.Models.UsersDatabase;
+
+namespace VirtualFinland.UsersAPI.UnitTests.Helpers;
+
+internal class TermsOfServiceBuilder
+{
+    public static TermsOfService Build()
+    {
+        return new TermsOfService
+        {
+            Url = "https://test.localhost/terms-of-service",
+            Version = "1.0.0",
+            Description = "Test terms of service"
+        };
+    }
+}

--- a/VirtualFinland.UsersAPI.UnitTests/Tests/Security/TermsOfServiceAggreementVerifyTests.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Tests/Security/TermsOfServiceAggreementVerifyTests.cs
@@ -1,0 +1,41 @@
+using FluentAssertions;
+using VirtualFinland.UserAPI.Data.Repositories;
+using VirtualFinland.UserAPI.Exceptions;
+using VirtualFinland.UsersAPI.UnitTests.Helpers;
+
+namespace VirtualFinland.UsersAPI.UnitTests.Tests.Security;
+
+public class TermsOfServiceAggreementVerifyTests : APITestBase
+{
+    [Fact]
+    public async Task Should_InAuthVerification_ShouldThrowError()
+    {
+        // Arrange
+        await SetupTermsOfServices();
+        var (person, _, requestAuthenticatedUser) = await APIUserFactory.CreateAndGetLogInUser(_dbContext);
+        var (_, authenticationService, mockHttpContext) = GetGoodLoginRequestSituation(requestAuthenticatedUser, true);
+
+        // Act
+        var act = async () => await authenticationService.Authenticate(mockHttpContext.Object);
+
+        // Assert
+        await act.Should().ThrowAsync<NotAuthorizedException>();
+    }
+
+    [Fact]
+    public async Task Should_SuccessInAuthVerification()
+    {
+        // Arrange
+        var termsOfService = await SetupTermsOfServices();
+        var (person, _, requestAuthenticatedUser) = await APIUserFactory.CreateAndGetLogInUser(_dbContext);
+        var (_, authenticationService, mockHttpContext) = GetGoodLoginRequestSituation(requestAuthenticatedUser, true);
+        var termsOfServiceRepository = new TermsOfServiceRepository(GetMockedServiceProvider().Object);
+        await termsOfServiceRepository.AddNewTermsOfServiceAgreement(termsOfService, person.Id);
+
+        // Act
+        var authResult = await authenticationService.Authenticate(mockHttpContext.Object);
+
+        // Assert
+        authResult.PersonId.Should().Be(person.Id);
+    }
+}


### PR DESCRIPTION
- users-controllissa majailevan tossi-kyselyfunktion ei pitäisi varmistaa tossin hyväksyntää vaan ainoastaan palauttaa se:
  - heitti NotAuthorizedException jos tossia ei hyväksytty, kun olisi pitänyt vain palauttaa payloadi 
  - kirjautumisflow herjaa punaista uusilla käyttäjillä jos tossi-varmistus on päällä
- lisätty puuttuva testikeissi
