### PR TITLE
Add external service requests timeout handling to the security features

### DIFF
--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Extensions/HttpRequestExtension.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Extensions/HttpRequestExtension.cs
@@ -1,0 +1,20 @@
+namespace VirtualFinland.UserAPI.Helpers.Extensions;
+
+public static class HttpRequestExtensions
+{
+    private const string TimeoutPropertyKey = "RequestTimeout";
+
+    public static void SetTimeout(this HttpRequestMessage request, TimeSpan? timeout)
+    {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+        request.Options.Set(new HttpRequestOptionsKey<TimeSpan?>(TimeoutPropertyKey), timeout);
+    }
+
+    public static TimeSpan? GetTimeout(this HttpRequestMessage request)
+    {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+        if (request.Options.TryGetValue(new HttpRequestOptionsKey<TimeSpan?>(TimeoutPropertyKey), out var timeout))
+            return timeout;
+        return null;
+    }
+}

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/HttpRequestTimeoutHandler.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/HttpRequestTimeoutHandler.cs
@@ -1,0 +1,47 @@
+using VirtualFinland.UserAPI.Helpers.Extensions;
+
+namespace VirtualFinland.UserAPI.Helpers;
+
+/// <summary>
+/// Delegating handler that will throw a <see cref="TimeoutException" /> if the request times out.
+/// The timeout is determined by the <see cref="HttpRequestMessage.GetTimeout" /> extension method.
+/// If no timeout is specified, the <see cref="DefaultTimeout" /> will be used.
+/// </summary>
+/// <remarks>
+/// Inspired by Thomas Levesque article "Better timeout handling with HttpClient" (February 25, 2018)
+///  - https://thomaslevesque.com/2018/02/25/better-timeout-handling-with-httpclient/
+/// </remarks>
+public class HttpRequestTimeoutHandler : DelegatingHandler
+{
+    public TimeSpan DefaultTimeout { get; set; } = TimeSpan.FromSeconds(100);
+    public string DefaultTimeoutMessage { get; set; } = "Request timeout";
+
+    protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        using var cts = GetCancellationTokenSource(request, cancellationToken);
+        try
+        {
+            return await base.SendAsync(request, cts?.Token ?? cancellationToken);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException(DefaultTimeoutMessage);
+        }
+    }
+
+    private CancellationTokenSource? GetCancellationTokenSource(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var timeout = request.GetTimeout() ?? DefaultTimeout;
+        if (timeout == Timeout.InfiniteTimeSpan)
+        {
+            // No need to create a CTS if there's no timeout
+            return null;
+        }
+        else
+        {
+            var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(timeout);
+            return cts;
+        }
+    }
+}

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Services/DataspaceAudienceSecurityService.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Services/DataspaceAudienceSecurityService.cs
@@ -19,7 +19,6 @@ public class DataspaceAudienceSecurityService
         _httpClient = securityClientProviders.HttpClient;
     }
 
-
     public async Task VerifyAudience(string audience)
     {
         if (!_config.IsEnabled) return;

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Middleware/ErrorHandlerMiddleware.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Middleware/ErrorHandlerMiddleware.cs
@@ -105,6 +105,13 @@ public class ErrorHandlerMiddleware
                         }, HttpStatusCode.UnprocessableEntity);
                     }
                     break;
+                case TimeoutException:
+                    await WriteErrorResponse(context, new ErrorResponse()
+                    {
+                        Type = "Timeout",
+                        Message = error.Message ?? "Request timeout"
+                    }, HttpStatusCode.RequestTimeout);
+                    break;
                 default:
                     _logger.LogError(error, "Request processing failure!");
                     await WriteErrorResponse(context, new ErrorResponse()

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Middleware/ErrorHandlerMiddleware.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Middleware/ErrorHandlerMiddleware.cs
@@ -106,7 +106,6 @@ public class ErrorHandlerMiddleware
                     }
                     break;
                 case TimeoutException:
-                    _logger.LogError(error, "Request timeout on external service");
                     await WriteErrorResponse(context, new ErrorResponse()
                     {
                         Type = "RequestTimeout",

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Middleware/ErrorHandlerMiddleware.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Middleware/ErrorHandlerMiddleware.cs
@@ -106,10 +106,11 @@ public class ErrorHandlerMiddleware
                     }
                     break;
                 case TimeoutException:
+                    _logger.LogError(error, "Request timeout on external service");
                     await WriteErrorResponse(context, new ErrorResponse()
                     {
-                        Type = "Timeout",
-                        Message = error.Message ?? "Request timeout"
+                        Type = "RequestTimeout",
+                        Message = error.Message ?? "Request timeout on external service"
                     }, HttpStatusCode.RequestTimeout);
                     break;
                 default:

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/ApplicationSecurity.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/ApplicationSecurity.cs
@@ -1,8 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
-using Microsoft.Extensions.Options;
 using VirtualFinland.UserAPI.Data.Repositories;
 using VirtualFinland.UserAPI.Exceptions;
-using VirtualFinland.UserAPI.Security.Features;
 using VirtualFinland.UserAPI.Security.Models;
 
 namespace VirtualFinland.UserAPI.Security;

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Configurations/AudienceGuardConfig.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Configurations/AudienceGuardConfig.cs
@@ -2,6 +2,6 @@ namespace VirtualFinland.UserAPI.Security.Configurations;
 
 public class AudienceGuardConfig
 {
-    public AudienceGuardStaticConfig StaticConfig { get; set; } = default!;
-    public AudienceGuardServiceConfig Service { get; set; } = default!;
+    public AudienceGuardStaticConfig StaticConfig { get; set; } = new();
+    public AudienceGuardServiceConfig Service { get; set; } = new();
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Configurations/AudienceGuardServiceConfig.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Configurations/AudienceGuardServiceConfig.cs
@@ -2,7 +2,7 @@ namespace VirtualFinland.UserAPI.Security.Configurations;
 
 public class AudienceGuardServiceConfig
 {
-    public string ApiEndpoint { get; init; } = default!;
-    public List<string> AllowedGroups { get; init; } = default!;
-    public bool IsEnabled { get; init; }
+    public string ApiEndpoint { get; init; } = string.Empty;
+    public List<string> AllowedGroups { get; init; } = new();
+    public bool IsEnabled { get; init; } = false;
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Configurations/AudienceGuardStaticConfig.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Configurations/AudienceGuardStaticConfig.cs
@@ -2,6 +2,6 @@ namespace VirtualFinland.UserAPI.Security.Configurations;
 
 public class AudienceGuardStaticConfig
 {
-    public List<string> AllowedAudiences { get; set; } = new List<string>();
+    public List<string> AllowedAudiences { get; set; } = new();
     public bool IsEnabled { get; set; } = false;
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Extensions/SecurityFeatureServiceExtensions.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Extensions/SecurityFeatureServiceExtensions.cs
@@ -28,7 +28,14 @@ public static class SecurityFeatureServiceExtensions
 
         var securityClientProviders = new SecurityClientProviders()
         {
-            HttpClient = new HttpClient(),
+            HttpClient = new HttpClient(
+                new HttpRequestTimeoutHandler
+                {
+                    DefaultTimeout = TimeSpan.FromSeconds(3),
+                    DefaultTimeoutMessage = "Security feature request timeout",
+                    InnerHandler = new HttpClientHandler()
+                }
+            ),
             CacheRepositoryFactory = new CacheRepositoryFactory(redis.GetDatabase(), Constants.Security.CachePrefix),
         };
 

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Extensions/SecurityFeatureServiceExtensions.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Extensions/SecurityFeatureServiceExtensions.cs
@@ -31,7 +31,7 @@ public static class SecurityFeatureServiceExtensions
             HttpClient = new HttpClient(
                 new HttpRequestTimeoutHandler
                 {
-                    DefaultTimeout = TimeSpan.FromSeconds(3),
+                    DefaultTimeout = TimeSpan.FromSeconds(6),
                     DefaultTimeoutMessage = "Security feature request timeout",
                     InnerHandler = new HttpClientHandler()
                 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Extensions/SecurityFeatureServiceExtensions.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Extensions/SecurityFeatureServiceExtensions.cs
@@ -23,6 +23,7 @@ public static class SecurityFeatureServiceExtensions
         var features = new List<ISecurityFeature>();
 
         var securityConfigurations = configuration.GetSection("Security:Authorization").Get<Dictionary<string, SecurityFeatureOptions>>();
+        var securityOptions = configuration.GetSection("Security:Options").Get<SecurityOptions>();
         var enabledSecurityFeatureNames = securityConfigurations.Where(x => x.Value.IsEnabled).Select(x => x.Key).ToArray();
         if (!enabledSecurityFeatureNames.Any()) throw new ArgumentException("No security features enabled");
 
@@ -31,7 +32,7 @@ public static class SecurityFeatureServiceExtensions
             HttpClient = new HttpClient(
                 new HttpRequestTimeoutHandler
                 {
-                    DefaultTimeout = TimeSpan.FromSeconds(6),
+                    DefaultTimeout = TimeSpan.FromMilliseconds(securityOptions.ServiceRequestTimeoutInMilliseconds),
                     DefaultTimeoutMessage = "Security feature request timeout",
                     InnerHandler = new HttpClientHandler()
                 }
@@ -48,7 +49,7 @@ public static class SecurityFeatureServiceExtensions
         }
 
         // Register security setup
-        services.AddSingleton(new SecuritySetup { Features = features, Options = configuration.GetSection("Security:Options").Get<SecurityOptions>() });
+        services.AddSingleton(new SecuritySetup { Features = features, Options = securityOptions });
 
         // Register app security instance
         services.AddSingleton<IApplicationSecurity, ApplicationSecurity>();

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Models/SecurityFeatureOptions.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Models/SecurityFeatureOptions.cs
@@ -8,5 +8,5 @@ public class SecurityFeatureOptions
     public string? AuthorizationJwksJsonUrl { get; set; }
     public string? Issuer { get; set; } = default!;
     public bool IsEnabled { get; set; }
-    public AudienceGuardConfig AudienceGuard { get; set; } = default!;
+    public AudienceGuardConfig AudienceGuard { get; set; } = new();
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Models/SecurityOptions.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Models/SecurityOptions.cs
@@ -3,4 +3,5 @@ namespace VirtualFinland.UserAPI.Security.Models;
 public class SecurityOptions
 {
     public bool TermsOfServiceAgreementRequired { get; set; }
+    public int ServiceRequestTimeoutInMilliseconds { get; set; }
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.json
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.json
@@ -79,7 +79,8 @@
       }
     },
     "Options": {
-      "TermsOfServiceAgreementRequired": false
+      "TermsOfServiceAgreementRequired": false,
+      "ServiceRequestTimeoutInMilliseconds": 6000
     }
   },
   "ConnectionStrings": {

--- a/VirtualFinland.UsersAPI.UnitTests/Helpers/APITestBase.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Helpers/APITestBase.cs
@@ -79,7 +79,8 @@ public class APITestBase
                 },
                 Options = new SecurityOptions()
                 {
-                    TermsOfServiceAgreementRequired = false
+                    TermsOfServiceAgreementRequired = false,
+                    ServiceRequestTimeoutInMilliseconds = 1000
                 }
             }
         );

--- a/VirtualFinland.UsersAPI.UnitTests/Helpers/TestSecurityFeature.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Helpers/TestSecurityFeature.cs
@@ -1,0 +1,24 @@
+using VirtualFinland.UserAPI.Exceptions;
+using VirtualFinland.UserAPI.Security.Features;
+using VirtualFinland.UserAPI.Security.Models;
+
+namespace VirtualFinland.UsersAPI.UnitTests.Helpers;
+
+public class TestSecurityFeature : SecurityFeature
+{
+    public TestSecurityFeature(SecurityFeatureOptions options, SecurityClientProviders securityClientProviders) : base(options, securityClientProviders)
+    {
+    }
+
+    /// <summary>
+    /// Validates the token audience by external service
+    /// </summary>
+    /// <param name="audience"></param>
+    /// <exception cref="NotAuthorizedException"></exception>
+    public override async Task ValidateSecurityTokenAudienceByService(string audience)
+    {
+        var verifyUrl = $"{_options.AudienceGuard.Service.ApiEndpoint}?audience={audience}";
+        using var response = await _securityClientProviders.HttpClient.GetAsync(verifyUrl);
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/VirtualFinland.UsersAPI.UnitTests/Tests/Security/TimeoutTests.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Tests/Security/TimeoutTests.cs
@@ -19,6 +19,9 @@ public class TimeoutTests : APITestBase
 {
 
     [Fact]
+    ///
+    /// Test that the security feature times out when retrieving service information using the AudienceGuardService feature
+    /// 
     public async Task Should_RetrievingSecurityServiceInformation_shouldThrowTimeoutException()
     {
         // Arrange

--- a/VirtualFinland.UsersAPI.UnitTests/Tests/Security/TimeoutTests.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Tests/Security/TimeoutTests.cs
@@ -1,0 +1,106 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using VirtualFinland.UserAPI.Exceptions;
+using VirtualFinland.UserAPI.Security;
+using VirtualFinland.UserAPI.Helpers.Services;
+using VirtualFinland.UsersAPI.UnitTests.Helpers;
+using VirtualFinland.UserAPI.Security.Features;
+using VirtualFinland.UserAPI.Data.Repositories;
+using VirtualFinland.UserAPI.Security.Models;
+using VirtualFinland.UserAPI.Security.Configurations;
+using VirtualFinland.UserAPI.Helpers;
+using System.Net;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Microsoft.IdentityModel.Tokens;
+using Moq.Protected;
+
+namespace VirtualFinland.UsersAPI.UnitTests.Tests.Security;
+
+public class TimeoutTests : APITestBase
+{
+
+    [Fact]
+    public async Task Should_RetrievingSecurityServiceInformation_shouldThrowTimeoutException()
+    {
+        // Arrange
+        var innerHandler = new Mock<HttpMessageHandler>();
+        innerHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Returns(async () =>
+            {
+                await Task.Delay(2);
+                return new HttpResponseMessage()
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("dummy")
+                };
+            });
+        var httpClient = new HttpClient(new HttpRequestTimeoutHandler
+        {
+            DefaultTimeout = TimeSpan.FromMilliseconds(1),
+            DefaultTimeoutMessage = "Security feature request timeout",
+            InnerHandler = new HttpClientHandler()
+        });
+
+        var securityClientProviders = new SecurityClientProviders()
+        {
+            HttpClient = httpClient,
+            CacheRepositoryFactory = new Mock<ICacheRepositoryFactory>().Object,
+        };
+
+        var applicationSecurity = new ApplicationSecurity(
+            new TermsOfServiceRepository(GetMockedServiceProvider().Object),
+            new SecuritySetup()
+            {
+                Features = new List<ISecurityFeature>() {
+                    new TestSecurityFeature(
+                        new SecurityFeatureOptions {
+                            Issuer = "dummy",
+                            OpenIdConfigurationUrl = "http://dummy",
+                            AudienceGuard = new AudienceGuardConfig {
+                                StaticConfig = new AudienceGuardStaticConfig {
+                                    IsEnabled = false,
+                                    AllowedAudiences = new List<string> { "dummy" }
+                                },
+                                Service = new AudienceGuardServiceConfig {
+                                    IsEnabled = true,
+                                    ApiEndpoint = "http://dummy",
+                                    AllowedGroups = new List<string> { "dummy" }
+                                }
+                            }
+                        },
+                        securityClientProviders
+                    )
+                },
+                Options = new SecurityOptions()
+                {
+                    TermsOfServiceAgreementRequired = false,
+                    ServiceRequestTimeoutInMilliseconds = 1
+                }
+            }
+        );
+
+        // Create mock jwt token
+        var idToken = new JwtSecurityTokenHandler().WriteToken(new JwtSecurityToken(
+            "dummy",
+            "dummy",
+            new List<Claim>
+            {
+                new("sub", "dummy"),
+            },
+            DateTime.Now,
+            DateTime.Now.AddDays(1),
+            new SigningCredentials(new SymmetricSecurityKey(new byte[16]), SecurityAlgorithms.HmacSha256)
+        ));
+
+        // Act
+        var act = () => applicationSecurity.ParseJwtToken(idToken);
+
+        // Assert
+        await act.Should().ThrowAsync<TimeoutException>();
+    }
+}

--- a/VirtualFinland.UsersAPI.UnitTests/Tests/Security/TimeoutTests.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Tests/Security/TimeoutTests.cs
@@ -1,11 +1,6 @@
 using FluentAssertions;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Configuration;
 using Moq;
-using VirtualFinland.UserAPI.Exceptions;
 using VirtualFinland.UserAPI.Security;
-using VirtualFinland.UserAPI.Helpers.Services;
 using VirtualFinland.UsersAPI.UnitTests.Helpers;
 using VirtualFinland.UserAPI.Security.Features;
 using VirtualFinland.UserAPI.Data.Repositories;
@@ -27,12 +22,15 @@ public class TimeoutTests : APITestBase
     public async Task Should_RetrievingSecurityServiceInformation_shouldThrowTimeoutException()
     {
         // Arrange
+        var requestDelay = 2;
+        var requestTimeout = 1;
+
         var innerHandler = new Mock<HttpMessageHandler>();
         innerHandler.Protected()
             .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
             .Returns(async () =>
             {
-                await Task.Delay(2);
+                await Task.Delay(requestDelay);
                 return new HttpResponseMessage()
                 {
                     StatusCode = HttpStatusCode.OK,
@@ -41,7 +39,7 @@ public class TimeoutTests : APITestBase
             });
         var httpClient = new HttpClient(new HttpRequestTimeoutHandler
         {
-            DefaultTimeout = TimeSpan.FromMilliseconds(1),
+            DefaultTimeout = TimeSpan.FromMilliseconds(requestTimeout),
             DefaultTimeoutMessage = "Security feature request timeout",
             InnerHandler = new HttpClientHandler()
         });


### PR DESCRIPTION
The authentication / authorization features of the users-api require fetching data from external services like sinuna, dataspace, etc.  These security dependencies are treated as high-priority and should never have long delays in the request. 

This PR sets a request timeout limit of 6 seconds and handling to these security feature requests and a simple test case that ensures the timeout exception is thrown when expected.