### PR TITLE
Cleanups and adjustments

### DIFF
--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/User/GetUserProfile.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/User/GetUserProfile.cs
@@ -49,7 +49,6 @@ public static class GetUserProfile
                 .Include(p => p.AdditionalInformation).ThenInclude(ai => ai!.Address)
                 .SingleAsync(p => p.Id == request.User.PersonId, cancellationToken);
 
-            // TODO - To be decided: This default search profile in the user API call can be possibly removed when requirement are more clear
             var dbUserDefaultSearchProfile = await _usersDbContext.SearchProfiles.FirstOrDefaultAsync(o => o.IsDefault && o.PersonId == dbUser.Id, cancellationToken);
 
             List<UserResponseOccupation>? occupations = null;

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/User/UpdateUserProfile.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/Productizer/Operations/User/UpdateUserProfile.cs
@@ -232,9 +232,6 @@ public static class UpdateUserProfile
             return validationErrors;
         }
 
-        /// <summary>
-        /// TODO - To be decided: This default search profile in the user API call can be possibly removed when requirement are more clear
-        /// </summary>
         /// <param name="dbUserDefaultSearchProfile"></param>
         /// <param name="dbUser"></param>
         /// <param name="request"></param>

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/GetUser.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/GetUser.cs
@@ -47,7 +47,6 @@ public static class GetUser
                 .Include(u => u.AdditionalInformation).ThenInclude(ai => ai!.Address)
                 .SingleAsync(o => o.Id == request.User.PersonId, cancellationToken);
 
-            // TODO - To be decided: This default search profile in the user API call can be possibly removed when requirement are more clear
             var dbUserDefaultSearchProfile = await _usersDbContext.SearchProfiles.FirstOrDefaultAsync(o => o.IsDefault && o.PersonId == dbUser.Id, cancellationToken);
 
             List<UserResponseOccupation>? occupations = null;

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/UpdateUser.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/UpdateUser.cs
@@ -370,9 +370,6 @@ public static class UpdateUser
             return validationErrors;
         }
 
-        /// <summary>
-        /// TODO - To be decided: This default search profile in the user API call can be possibly removed when requirement are more clear
-        /// </summary>
         /// <param name="dbUserDefaultSearchProfile"></param>
         /// <param name="dbUser"></param>
         /// <param name="request"></param>

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/UpdateUser.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Activities/User/Operations/UpdateUser.cs
@@ -294,11 +294,7 @@ public static class UpdateUser
                         continue;
                     }
 
-                    var existingOccupation = dbUserOccupations.FirstOrDefault(o => o.Id == occupation.Id);
-
-                    // TODO: Return some error about invalid guid ?
-                    if (existingOccupation is null) continue;
-
+                    var existingOccupation = dbUserOccupations.FirstOrDefault(o => o.Id == occupation.Id) ?? throw new BadRequestException("Invalid occupation ID");
                     if (occupation.Delete is true)
                     {
                         dbUserOccupations.Remove(existingOccupation);

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Extensions/EnvironmentExtensions.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Extensions/EnvironmentExtensions.cs
@@ -5,7 +5,9 @@ public static class Environments
     public static readonly string Local = "local";
     public static readonly string Development = "dev";
     public static readonly string Staging = "staging";
-    public static readonly string Production = "prod";
+    public static readonly string Production = "production";
+    public static readonly string MvpStaging = "mvp-staging";
+    public static readonly string MvpProduction = "mvp-production";
 }
 
 public static class EnvironmentExtensions
@@ -34,19 +36,19 @@ public static class EnvironmentExtensions
     {
         if (hostEnvironment == null)
         {
-            throw new ArgumentException(nameof(hostEnvironment));
+            throw new ArgumentException(null, nameof(hostEnvironment));
         }
 
-        return hostEnvironment.IsEnvironment(Environments.Staging);
+        return hostEnvironment.IsEnvironment(Environments.MvpStaging) || hostEnvironment.IsEnvironment(Environments.Staging);
     }
 
     public static bool IsProduction(this IHostEnvironment hostEnvironment)
     {
         if (hostEnvironment == null)
         {
-            throw new ArgumentException(nameof(hostEnvironment));
+            throw new ArgumentException(null, nameof(hostEnvironment));
         }
 
-        return hostEnvironment.IsEnvironment(Environments.Production);
+        return hostEnvironment.IsEnvironment(Environments.MvpProduction) || hostEnvironment.IsEnvironment(Environments.Production);
     }
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20230906150120_TermsOfService.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Migrations/20230906150120_TermsOfService.cs
@@ -68,7 +68,6 @@ namespace VirtualFinland.UserAPI.Migrations
                 column: "Version",
                 unique: true);
 
-            // @TODO Manage terms of service by some control mechanism and not by migrations
             migrationBuilder.InsertData(
                 table: "TermsOfServices",
                 columns: new[] { "Id", "Url", "Description", "Version", "Created", "Modified" },

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/UsersDatabase/Auditable.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Models/UsersDatabase/Auditable.cs
@@ -30,13 +30,13 @@ public class Auditable : IAuditable
 
     protected void SetupAuditAddition(IRequestAuthenticationCandinate user)
     {
-        Created = DateTime.Now;
+        Created = DateTime.UtcNow;
         SetupAuditUpdate(user);
     }
 
     protected void SetupAuditUpdate(IRequestAuthenticationCandinate user)
     {
-        Modified = DateTime.Now;
+        Modified = DateTime.UtcNow;
         Metadata = new AuditableMetadata(user);
     }
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Program.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Program.cs
@@ -168,19 +168,12 @@ builder.Services.AddSingleton<AnalyticsService>();
 //
 var app = builder.Build();
 
-// Use swagger only in non-production environments
-if (!EnvironmentExtensions.IsProduction(app.Environment))
+// Use swagger only in development
+if (EnvironmentExtensions.IsLocal(app.Environment) || EnvironmentExtensions.IsDevelopment(app.Environment))
 {
     app.UseSwagger();
     app.UseSwaggerUI();
-
-    // global cors policy
-    app.UseCors(x => x
-        .AllowAnyOrigin()
-        .AllowAnyMethod()
-        .AllowAnyHeader());
 }
-
 
 app.UseSerilogRequestLogging(options =>
 {

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Program.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Program.cs
@@ -118,7 +118,6 @@ builder.Services.AddDbContext<UsersDbContext>(options =>
             .UseQuerySplittingBehavior(QuerySplittingBehavior.SingleQuery)
         );
 });
-AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true); // @TODO: Resolve what changed in datetime inserting that causes this to be needed
 
 //
 // Redis connection

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Program.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Program.cs
@@ -172,6 +172,12 @@ if (EnvironmentExtensions.IsLocal(app.Environment) || EnvironmentExtensions.IsDe
 {
     app.UseSwagger();
     app.UseSwaggerUI();
+
+    // Direct cors requests used in dev-stages
+    app.UseCors(builder => builder
+        .AllowAnyOrigin()
+        .AllowAnyMethod()
+        .AllowAnyHeader());
 }
 
 app.UseSerilogRequestLogging(options =>

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Features/ISecurityFeature.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Features/ISecurityFeature.cs
@@ -13,4 +13,5 @@ public interface ISecurityFeature
     Task ValidateSecurityTokenAudience(string audience);
 
     public string Issuer { get; }
+    public bool IsInitialized { get; set; }
 }

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Features/TestbedSecurityFeature.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Features/TestbedSecurityFeature.cs
@@ -1,4 +1,3 @@
-using VirtualFinland.UserAPI.Data.Repositories;
 using VirtualFinland.UserAPI.Security.Models;
 
 namespace VirtualFinland.UserAPI.Security.Features;

--- a/VirtualFinland.UsersAPI.Deployment/Features/PostgresDatabase.cs
+++ b/VirtualFinland.UsersAPI.Deployment/Features/PostgresDatabase.cs
@@ -95,7 +95,7 @@ public class PostgresDatabase
 
             DbSubnetGroupName = dbSubNetGroup.Name,
             Tags = stackSetup.Tags,
-            BackupRetentionPeriod = 7, // @TODO: Define for production
+            BackupRetentionPeriod = 30,
             EnabledCloudwatchLogsExports = new[] { "postgresql" },
         });
 

--- a/VirtualFinland.UsersAPI.UnitTests/Helpers/APITestBase.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Helpers/APITestBase.cs
@@ -49,8 +49,8 @@ public class APITestBase
             {
                 new("sub", requestAuthenticationCandinate.IdentityId ?? throw new Exception("IdentityId is null")),
             },
-            DateTime.Now,
-            DateTime.Now.AddDays(1),
+            DateTime.UtcNow,
+            DateTime.UtcNow.AddDays(1),
             new SigningCredentials(new SymmetricSecurityKey(new byte[16]), SecurityAlgorithms.HmacSha256)
         ));
 

--- a/VirtualFinland.UsersAPI.UnitTests/Helpers/APITestBase.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Helpers/APITestBase.cs
@@ -66,7 +66,7 @@ public class APITestBase
             new SecuritySetup()
             {
                 Features = new List<ISecurityFeature>() {
-                    new SecurityFeature(
+                    new TestSecurityFeature(
                         new SecurityFeatureOptions {
                             Issuer = requestAuthenticationCandinate.Issuer,
                             OpenIdConfigurationUrl = "test-openid-config-url",

--- a/VirtualFinland.UsersAPI.UnitTests/Helpers/PersonAdditionalInformationBuilder.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Helpers/PersonAdditionalInformationBuilder.cs
@@ -18,7 +18,7 @@ public class PersonAdditionalInformationBuilder
     private readonly string _citizenshipCode = "FR";
     private readonly string _countryOfBirthCode = "FR";
     private readonly DateTime _created = DateTime.UtcNow;
-    private readonly DateOnly _dateOfBirth = DateOnly.FromDateTime(DateTime.Now);
+    private readonly DateOnly _dateOfBirth = DateOnly.FromDateTime(DateTime.UtcNow);
     private readonly string _gender = "Male";
     private readonly DateTime _modified = DateTime.UtcNow;
     private readonly string _nativeLanguageCode = "FR";

--- a/VirtualFinland.UsersAPI.UnitTests/Helpers/TestSecurityFeature.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Helpers/TestSecurityFeature.cs
@@ -8,6 +8,7 @@ public class TestSecurityFeature : SecurityFeature
 {
     public TestSecurityFeature(SecurityFeatureOptions options, SecurityClientProviders securityClientProviders) : base(options, securityClientProviders)
     {
+        IsInitialized = true;
     }
 
     /// <summary>

--- a/VirtualFinland.UsersAPI.UnitTests/Tests/Security/TimeoutTests.cs
+++ b/VirtualFinland.UsersAPI.UnitTests/Tests/Security/TimeoutTests.cs
@@ -93,8 +93,8 @@ public class TimeoutTests : APITestBase
             {
                 new("sub", "dummy"),
             },
-            DateTime.Now,
-            DateTime.Now.AddDays(1),
+            DateTime.UtcNow,
+            DateTime.UtcNow.AddDays(1),
             new SigningCredentials(new SymmetricSecurityKey(new byte[16]), SecurityAlgorithms.HmacSha256)
         ));
 


### PR DESCRIPTION
- enable swagger only on development and local environments
- fix the `Npgsql.EnableLegacyTimestampBehavior` setting related todo: 
  - in dotnet use `DateTime.UtcNow` instead of `DateTime.Now` when saving to db context
- set daily backup retention time to 30 days in prod
- clear the search profile related TODO-flags as resolved by the current implementation
- add error handling to the users controller occupations save phase
- ensure the security features initialization is completed before handling of a restricted request
