### PR TITLE
Terms of service documentation

### DIFF
--- a/Docs/README.adminfunction.md
+++ b/Docs/README.adminfunction.md
@@ -42,6 +42,7 @@ dotnet run --project ./VirtualFinland.UsersAPI.AdminFunction.CLI migrate
 - `update-terms-of-service`:
   - lambda function payload: `{"Action": "UpdateTermsOfService"}`
   - cli command: `dotnet run --project ./VirtualFinland.UsersAPI.AdminFunction.CLI update-terms-of-service`
+  - read more at [./README.terms-of-service.md](./README.terms-of-service.md) document
 - `update-analytics`:
   - lambda function payload: `{"Action": "UpdateAnalytics"}`
 - `invalidate-caches`: invalidates the api gateway caches

--- a/Docs/README.security.md
+++ b/Docs/README.security.md
@@ -24,7 +24,7 @@ Currently only Sinuna authentication provider has the implementation, as defined
 
 ### The enforcement of Access Finland MVP Terms of Service Agreement
 
-When used in the context of [Access Finland MVP](https://github.com/Virtual-Finland-Development/access-finland) application the users-api request authentication/authorization phase requires that user has agreed to the af-mvp Terms of Service. The enforcement can be enabled or disabled using with the `Security.Options.TermsOfServiceAgreementRequired` property in the [appsettings.json](../VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.json)-file.
+When used in the context of [Access Finland MVP](https://github.com/Virtual-Finland-Development/access-finland) application the users-api request authentication phase requires that the user has agreed to the terms of service of the Access Finland MVP. The enforcement can be enabled or disabled using with the `Security.Options.TermsOfServiceAgreementRequired` property in the [appsettings.json](../VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.json)-file and is disabled by default. The actual enforcement is implemented in the `VerifyPersonTermsOfServiceAgreement` method of the [ApplicationSecurity.cs](../VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/ApplicationSecurity.cs)-file.
 
 Read more at [./README.terms-of-service.md](./README.terms-of-service.md) document.
 

--- a/Docs/README.security.md
+++ b/Docs/README.security.md
@@ -22,6 +22,12 @@ The audience validation is configured in the [appsettings.json](../VirtualFinlan
 
 Currently only Sinuna authentication provider has the implementation, as defined in the [SinunaSecurityFeature.cs](../VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Security/Features/SinunaSecurityFeature.cs)-file. With Sinuna, the audience guard service ([DataspaceAudienceSecurityService.cs](../VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Helpers/Services/DataspaceAudienceSecurityService.cs)-file) retrieves the audience from the dataspace service API and validates that the audience is configured in a group of intrest. The allowed groups are configured in the [appsettings.json](../VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.json)-file properties block: `Security:Authorization:Sinuna:AudienceGuard:Service:AllowedGroups`.
 
+### The enforcement of Access Finland MVP Terms of Service Agreement
+
+When used in the context of [Access Finland MVP](https://github.com/Virtual-Finland-Development/access-finland) application the users-api request authentication/authorization phase requires that user has agreed to the af-mvp Terms of Service. The enforcement can be enabled or disabled using with the `Security.Options.TermsOfServiceAgreementRequired` property in the [appsettings.json](../VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.json)-file.
+
+Read more at [./README.terms-of-service.md](./README.terms-of-service.md) document.
+
 ## Controller Specific Guards
 
 ### RequestFromAccessFinland Policy

--- a/Docs/README.terms-of-service.md
+++ b/Docs/README.terms-of-service.md
@@ -6,7 +6,7 @@ The users-api, when used as part of the [Access Finland MVP](https://github.com/
 
 The service terms are provided and managed by the Access Finland MVP application, but it uses the users-api as the backend service that keeps track of the accepted terms. This means that the users-api has to have some reference to which terms of service versions exists, so that it can validate which version the user has accepted. 
 
-The versions are stored in the users-api database in the `TermsOfServices` table and is managed using the [admin function](./README.adminfunction.md) action `update-terms-of-service`. The action performs a syncronization between the database and the a json-file that contains the terms of service versions. The json-file is located at [../Data/terms-of-services.json](../Data/terms-of-services.json) and it contains a list of terms of service versions, where each version has the following properties:
+The versions are stored in the users-api database in the `TermsOfServices` table and is managed using the [admin function](./README.adminfunction.md) action `update-terms-of-service`. The action performs a syncronization between the database and a json-file that contains the terms of service versions. The json-file is located at [../Data/terms-of-services.json](../Data/terms-of-services.json) and it contains a list of terms of service versions, where each version has the following properties:
 
 - `version`: the sematic version of the terms of service, used as key
 - `url`: the url to the terms of service document

--- a/Docs/README.terms-of-service.md
+++ b/Docs/README.terms-of-service.md
@@ -1,6 +1,6 @@
 # Terms of service 
 
-The users-api, when used as part of the Access Finland MVP application, is subject to the terms of service of the app. The requirement is that the user has to accept the terms of service before accessing the relevant data. It is also required that the service keeps track of which users have accepted the terms and which version of the terms they have accepted. 
+The users-api, when used as part of the [Access Finland MVP](https://github.com/Virtual-Finland-Development/access-finland) application, is subject to the terms of service of the app. The requirement is that the user has to accept the terms of service before accessing the relevant data. It is also required that the service keeps track of which users have accepted the terms and which version of the terms they have accepted. 
 
 ## Terms of service version references management
 

--- a/Docs/README.terms-of-service.md
+++ b/Docs/README.terms-of-service.md
@@ -17,6 +17,6 @@ The versions are stored in the users-api database in the `TermsOfServices` table
 
 As it is required that the user has accepted the terms of service before accessing the relevant data, the users-api has to enforce this requirement. This is done as a part of the authentication process better described in the [API Security Features](./README.security.md) document.
 
-## Using the api from third-party applications
+## Using the API from third-party applications
 
-The users-api provided ToS-subjected relevant data is accessed through the dataspace gateway service, which means that in theory it would be possible to access the user data from third-party applications as well (in a controlled manner). If this is the case, the third-party application has to inform the user that the data is not accessible before accepting the Access Finland MVP terms of service and that the terms can only be accepted through the Access Finland MVP application.
+The users-api provided ToS-subjected relevant data is accessed through the dataspace gateway service, which means that in theory it would be possible to access the user data from third-party applications as well (in a controlled manner). If this is the use-case, the third-party application has to inform the user that the data is not accessible before accepting the Access Finland MVP terms of service and that the terms can only be accepted through the Access Finland MVP application.

--- a/Docs/README.terms-of-service.md
+++ b/Docs/README.terms-of-service.md
@@ -6,7 +6,7 @@ The users-api, when used as part of the [Access Finland MVP](https://github.com/
 
 The terms of service are provided and managed by the Access Finland MVP application, but it uses the users-api as the service that keeps track of the accepted terms. This means that the users-api has to have some reference to which terms of service versions exists so that it can validate which version the user has accepted. 
 
-The versions are stored in the users-api database in the `TermsOfServices` table and is managed using the admin function script `update-terms-of-service`. The script performs a syncronization between the database and the a json-file that contains the terms of service versions. The json-file is located at [../Data/terms-of-services.json](../Data/terms-of-services.json) and it contains a list of terms of service versions, where each version has the following properties:
+The versions are stored in the users-api database in the `TermsOfServices` table and is managed using the [admin function](./README.adminfunction.md) action `update-terms-of-service`. The action performs a syncronization between the database and the a json-file that contains the terms of service versions. The json-file is located at [../Data/terms-of-services.json](../Data/terms-of-services.json) and it contains a list of terms of service versions, where each version has the following properties:
 
 - `version`: the sematic version of the terms of service, used as key
 - `url`: the url to the terms of service document

--- a/Docs/README.terms-of-service.md
+++ b/Docs/README.terms-of-service.md
@@ -4,7 +4,7 @@ The users-api, when used as part of the [Access Finland MVP](https://github.com/
 
 ## Terms of service version references management
 
-The terms of service are provided and managed by the Access Finland MVP application, but it uses the users-api as the service that keeps track of the accepted terms. This means that the users-api has to have some reference to which terms of service versions exists so that it can validate which version the user has accepted. 
+The service terms are provided and managed by the Access Finland MVP application, but it uses the users-api as the backend service that keeps track of the accepted terms. This means that the users-api has to have some reference to which terms of service versions exists, so that it can validate which version the user has accepted. 
 
 The versions are stored in the users-api database in the `TermsOfServices` table and is managed using the [admin function](./README.adminfunction.md) action `update-terms-of-service`. The action performs a syncronization between the database and the a json-file that contains the terms of service versions. The json-file is located at [../Data/terms-of-services.json](../Data/terms-of-services.json) and it contains a list of terms of service versions, where each version has the following properties:
 

--- a/Docs/README.terms-of-service.md
+++ b/Docs/README.terms-of-service.md
@@ -1,0 +1,22 @@
+# Terms of service 
+
+The users-api, when used as part of the Access Finland MVP application, is subject to the terms of service of the app. The requirement is that the user has to accept the terms of service before accessing the relevant data. It is also required that the service keeps track of which users have accepted the terms and which version of the terms they have accepted. 
+
+## Terms of service version references management
+
+The terms of service are provided and managed by the Access Finland MVP application, but it uses the users-api as the service that keeps track of the accepted terms. This means that the users-api has to have some reference to which terms of service versions exists so that it can validate which version the user has accepted. 
+
+The versions are stored in the users-api database in the `TermsOfServices` table and is managed using the admin function script `update-terms-of-service`. The script performs a syncronization between the database and the a json-file that contains the terms of service versions. The json-file is located at [../Data/terms-of-services.json](../Data/terms-of-services.json) and it contains a list of terms of service versions, where each version has the following properties:
+
+- `version`: the sematic version of the terms of service, used as key
+- `url`: the url to the terms of service document
+- `description`: a short description of the terms of service version
+- `action`: the action that is performed when the syncronization script is run, can be `UPDATE` (default) or `REMOVE`. If the field is ommitted, the default action `UPDATE` is used.
+
+## Enforcement of the terms of service
+
+As it is required that the user has accepted the terms of service before accessing the relevant data, the users-api has to enforce this requirement. This is done as a part of the authentication process better described in the [API Security Features](./README.security.md) document.
+
+## Using the api from third-party applications
+
+The users-api provided ToS-subjected relevant data is accessed through the dataspace gateway service, which means that in theory it would be possible to access the user data from third-party applications as well (in a controlled manner). If this is the case, the third-party application has to inform the user that the data is not accessible before accepting the Access Finland MVP terms of service and that the terms can only be accepted through the Access Finland MVP application.

--- a/VirtualFinland.UsersAPI.AdminFunction/AdminApp/Actions/TermsOfServiceUpdateAction.cs
+++ b/VirtualFinland.UsersAPI.AdminFunction/AdminApp/Actions/TermsOfServiceUpdateAction.cs
@@ -38,7 +38,7 @@ public class TermsOfServiceUpdateAction : IAdminAppAction
             var existingTosItem = existingTermsOfServices.FirstOrDefault(tos => tos.Version == tossable.Version);
             if (existingTosItem == null)
             {
-                if (tossable.Action == "DELETE")
+                if (tossable.Action == TermsOfServiceUpdateItemAction.Delete)
                 {
                     // No need to delete something that does not exist
                     continue;
@@ -57,7 +57,7 @@ public class TermsOfServiceUpdateAction : IAdminAppAction
             }
             else
             {
-                if (tossable.Action == "DELETE")
+                if (tossable.Action == TermsOfServiceUpdateItemAction.Delete)
                 {
                     // Delete
                     _dataContext.TermsOfServices.Remove(existingTosItem);

--- a/VirtualFinland.UsersAPI.AdminFunction/AdminApp/Models/TermsOfServices/TermsOfServiceUpdateItem.cs
+++ b/VirtualFinland.UsersAPI.AdminFunction/AdminApp/Models/TermsOfServices/TermsOfServiceUpdateItem.cs
@@ -1,4 +1,6 @@
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+using VirtualFinland.UserAPI.Helpers;
 
 namespace VirtualFinland.AdminFunction.AdminApp.Models.TermsOfServices;
 
@@ -14,6 +16,7 @@ public class TermsOfServiceUpdateItem
     public TermsOfServiceUpdateItemAction? Action { get; set; }
 }
 
+[JsonConverter(typeof(JsonEnumMemberValueConverterFactory))]
 public enum TermsOfServiceUpdateItemAction
 {
     [EnumMember(Value = "UPDATE")] Update = 1,

--- a/VirtualFinland.UsersAPI.AdminFunction/AdminApp/Models/TermsOfServices/TermsOfServiceUpdateItem.cs
+++ b/VirtualFinland.UsersAPI.AdminFunction/AdminApp/Models/TermsOfServices/TermsOfServiceUpdateItem.cs
@@ -1,3 +1,5 @@
+using System.Runtime.Serialization;
+
 namespace VirtualFinland.AdminFunction.AdminApp.Models.TermsOfServices;
 
 public class TermsOfServiceUpdateItem
@@ -9,6 +11,11 @@ public class TermsOfServiceUpdateItem
     /// <summary>
     /// Special action to perform on the item
     /// </summary>
-    public string? Action { get; set; }
+    public TermsOfServiceUpdateItemAction? Action { get; set; }
 }
 
+public enum TermsOfServiceUpdateItemAction
+{
+    [EnumMember(Value = "UPDATE")] Update = 1,
+    [EnumMember(Value = "DELETE")] Delete = 2,
+}


### PR DESCRIPTION
- adds ToS-feature documentation
- clarifies the `update-terms-of-service` admin function action inputs:
  - only allow actions `UPDATE`=default and `DELETE`
   