### PR TITLE
Logging improvements

### DIFF
--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Program.cs
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/Program.cs
@@ -188,10 +188,11 @@ app.UseSerilogRequestLogging(options =>
 {
     options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
     {
+        diagnosticContext.Set("TraceId", httpContext.TraceIdentifier);
         if (httpContext.Items["Exception"] is Exception exception)
         {
             // Add the exception to the log context, omit the stack trace
-            diagnosticContext.Set("@x", $"{exception.GetType().Name}: {exception.Message}");
+            diagnosticContext.Set("Exception", $"{exception.GetType().Name}: {exception.Message}");
         }
     };
 });

--- a/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.local.json
+++ b/VirtualFinland.UserAPI/src/VirtualFinland.UsersAPI/appsettings.local.json
@@ -1,21 +1,4 @@
 {
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Debug",
-      "Override": {
-        "Microsoft.EntityFrameworkCore.Database.Command": "Information"
-      }
-    },
-    "WriteTo": [
-      {
-        "Name": "Console",
-        "Args": {
-          "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console",
-          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"
-        }
-      }
-    ]
-  },
   "Security": {
     "Authorization": {
       "Testbed": {


### PR DESCRIPTION
- adds traceId to normal serilogs
- renames the exception indicating log item `@@x` to just `Exception`
- sets the local logging to the same as in live environments