### PR TITLE
download-artifact/upload-artifact@v4

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Test and build
         run: make packages
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Application_Artifacts
           path: build-artifacts/

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: Application_Artifacts
           path: ./build-artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/actions@v5
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: Application_Artifacts
           path: ./build-artifacts


### PR DESCRIPTION
- node deprecations
- v4
- näissä oli jotain breaking changes, mutta liekkö vaikuttaa meidän use-caseen: https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/
- _includes up to 10x performance improvements_ - blazingly fast!